### PR TITLE
[WIP] Address audit report and misc improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,3 +15,7 @@ typechain/
 
 # files
 coverage.json
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,25 +1,22 @@
 extends:
-  - eslint:recommended
-  - plugin:@typescript-eslint/eslint-recommended
-  - plugin:@typescript-eslint/recommended
-  - prettier/@typescript-eslint
+  - "eslint:recommended"
+  - "plugin:@typescript-eslint/eslint-recommended"
+  - "plugin:@typescript-eslint/recommended"
+  - "prettier/@typescript-eslint"
 parser: "@typescript-eslint/parser"
 parserOptions:
-  project: tsconfig.json
+  project: "tsconfig.json"
 plugins:
   - "@typescript-eslint"
 root: true
 rules:
-  "@explicit-module-boundary-types":
-    - off
-
+  "@explicit-module-boundary-types": "off"
   "@typescript-eslint/no-floating-promises":
-    - error
+    - "error"
     - ignoreIIFE: true
       ignoreVoid: true
-
   "@typescript-eslint/no-inferrable-types": "off"
   "@typescript-eslint/no-unused-vars":
-    - error
+    - "error"
     - argsIgnorePattern: _
       varsIgnorePattern: _

--- a/@types/index.ts
+++ b/@types/index.ts
@@ -4,7 +4,6 @@ import { MockContract } from "ethereum-waffle";
 import { Signer } from "@ethersproject/abstract-signer";
 
 import { BalanceSheet } from "../typechain/BalanceSheet";
-import { Dai } from "./contracts/Dai";
 import { Erc20Mintable } from "../typechain/Erc20Mintable";
 import { Fintroller } from "../typechain/Fintroller";
 import { FyToken } from "../typechain/FyToken";
@@ -15,7 +14,6 @@ import { RedemptionPool } from "../typechain/RedemptionPool";
 import { TestOraclePriceUtils as OraclePriceUtils } from "../typechain/TestOraclePriceUtils";
 import { SimpleUniswapAnchoredView } from "../typechain/SimpleUniswapAnchoredView";
 import { UniswapAnchoredViewInterface } from "../typechain/UniswapAnchoredViewInterface";
-import { Weth9 } from "./contracts/Weth9";
 
 /* Fingers-crossed that ethers.js or waffle will provide an easier way to cache the address */
 export interface Accounts {
@@ -31,13 +29,13 @@ export interface Accounts {
 /* TODO: refactor this so that contract types differ for each test suite type. */
 export interface Contracts {
   balanceSheet: GodModeBalanceSheet | BalanceSheet;
-  collateral: Erc20Mintable | Weth9;
+  collateral: Erc20Mintable;
   fintroller: Fintroller;
   fyToken: GodModeFyToken | FyToken;
   oracle: SimpleUniswapAnchoredView | UniswapAnchoredViewInterface;
   oraclePriceUtils: OraclePriceUtils;
   redemptionPool: GodModeRedemptionPool | RedemptionPool;
-  underlying: Erc20Mintable | Dai;
+  underlying: Erc20Mintable;
 }
 
 /* The @nomiclabs/buidler-ganache is missing type extensions. */

--- a/contracts/BalanceSheet.sol
+++ b/contracts/BalanceSheet.sol
@@ -532,12 +532,13 @@ contract BalanceSheet is
      * Requirements:
      *
      * - The vault cannot be already open.
+     * - The fyToken must pass the inspection.
      *
      * @param fyToken The address of the fyToken contract for which to open the vault.
      * @return true = success, otherwise it reverts.
      */
     function openVault(FyTokenInterface fyToken) external override returns (bool) {
-        fyToken.isFyToken();
+        require(fyToken.isFyToken(), "ERR_OPEN_VAULT_FYTOKEN_INSPECTION");
         require(vaults[address(fyToken)][msg.sender].isOpen == false, "ERR_VAULT_OPEN");
         vaults[address(fyToken)][msg.sender].isOpen = true;
         emit OpenVault(fyToken, msg.sender);

--- a/contracts/BalanceSheet.sol
+++ b/contracts/BalanceSheet.sol
@@ -45,7 +45,7 @@ contract BalanceSheet is
      * CONSTANT FUNCTIONS
      */
 
-    struct CalculateClutchableCollateralLocalVars {
+    struct GetClutchableCollateralLocalVars {
         MathError mathErr;
         Exp clutchableCollateralAmountUpscaled;
         uint256 clutchableCollateralAmount;
@@ -77,7 +77,7 @@ contract BalanceSheet is
         override
         returns (uint256)
     {
-        CalculateClutchableCollateralLocalVars memory vars;
+        GetClutchableCollateralLocalVars memory vars;
 
         /* Avoid the zero edge cases. */
         require(repayAmount > 0, "ERR_GET_CLUTCHABLE_COLLATERAL_ZERO");

--- a/contracts/BalanceSheetInterface.sol
+++ b/contracts/BalanceSheetInterface.sol
@@ -17,7 +17,7 @@ abstract contract BalanceSheetInterface is BalanceSheetStorage {
         virtual
         returns (uint256);
 
-    function getCurrentCollateralizationRatio(FyTokenInterface fyToken, address account)
+    function getCurrentCollateralizationRatio(FyTokenInterface fyToken, address borrower)
         public
         view
         virtual
@@ -25,12 +25,12 @@ abstract contract BalanceSheetInterface is BalanceSheetStorage {
 
     function getHypotheticalCollateralizationRatio(
         FyTokenInterface fyToken,
-        address account,
+        address borrower,
         uint256 lockedCollateral,
         uint256 debt
     ) public view virtual returns (uint256);
 
-    function getVault(FyTokenInterface fyToken, address account)
+    function getVault(FyTokenInterface fyToken, address borrower)
         external
         view
         virtual
@@ -41,17 +41,17 @@ abstract contract BalanceSheetInterface is BalanceSheetStorage {
             bool
         );
 
-    function getVaultDebt(FyTokenInterface fyToken, address account) external view virtual returns (uint256);
+    function getVaultDebt(FyTokenInterface fyToken, address borrower) external view virtual returns (uint256);
 
-    function getVaultLockedCollateral(FyTokenInterface fyToken, address account)
+    function getVaultLockedCollateral(FyTokenInterface fyToken, address borrower)
         external
         view
         virtual
         returns (uint256);
 
-    function isAccountUnderwater(FyTokenInterface fyToken, address account) external view virtual returns (bool);
+    function isAccountUnderwater(FyTokenInterface fyToken, address borrower) external view virtual returns (bool);
 
-    function isVaultOpen(FyTokenInterface fyToken, address account) external view virtual returns (bool);
+    function isVaultOpen(FyTokenInterface fyToken, address borrower) external view virtual returns (bool);
 
     /**
      * NON-CONSTANT FUNCTIONS
@@ -74,7 +74,7 @@ abstract contract BalanceSheetInterface is BalanceSheetStorage {
 
     function setVaultDebt(
         FyTokenInterface fyToken,
-        address account,
+        address borrower,
         uint256 newVaultDebt
     ) external virtual returns (bool);
 
@@ -91,15 +91,15 @@ abstract contract BalanceSheetInterface is BalanceSheetStorage {
         uint256 clutchedCollateralAmount
     );
 
-    event DepositCollateral(FyTokenInterface indexed fyToken, address indexed account, uint256 collateralAmount);
+    event DepositCollateral(FyTokenInterface indexed fyToken, address indexed borrower, uint256 collateralAmount);
 
-    event FreeCollateral(FyTokenInterface indexed fyToken, address indexed account, uint256 collateralAmount);
+    event FreeCollateral(FyTokenInterface indexed fyToken, address indexed borrower, uint256 collateralAmount);
 
-    event LockCollateral(FyTokenInterface indexed fyToken, address indexed account, uint256 collateralAmount);
+    event LockCollateral(FyTokenInterface indexed fyToken, address indexed borrower, uint256 collateralAmount);
 
-    event OpenVault(FyTokenInterface indexed fyToken, address indexed account);
+    event OpenVault(FyTokenInterface indexed fyToken, address indexed borrower);
 
-    event SetVaultDebt(FyTokenInterface indexed fyToken, address indexed account, uint256 oldDebt, uint256 newDebt);
+    event SetVaultDebt(FyTokenInterface indexed fyToken, address indexed borrower, uint256 oldDebt, uint256 newDebt);
 
-    event WithdrawCollateral(FyTokenInterface indexed fyToken, address indexed account, uint256 collateralAmount);
+    event WithdrawCollateral(FyTokenInterface indexed fyToken, address indexed borrower, uint256 collateralAmount);
 }

--- a/contracts/Fintroller.sol
+++ b/contracts/Fintroller.sol
@@ -185,6 +185,42 @@ contract Fintroller is
     }
 
     /**
+     * @notice Updates the debt ceiling, which limits how much debt can be created in the bond market.
+     *
+     * @dev Emits a {SetBondDebtCeiling} event.
+     *
+     * Requirements:
+     *
+     * - The caller must be the administrator.
+     * - The bond must be listed.
+     * - The debt ceiling cannot be zero.
+     *
+     * @param fyToken The bond for which to update the debt ceiling.
+     * @param newDebtCeiling The uint256 value of the new debt ceiling, specified in the bond's decimal system.
+     * @return bool true = success, otherwise it reverts.
+     */
+    function setBondDebtCeiling(FyTokenInterface fyToken, uint256 newDebtCeiling)
+        external
+        override
+        onlyAdmin
+        returns (bool)
+    {
+        /* Checks: bond is listed. */
+        require(bonds[fyToken].isListed, "ERR_BOND_NOT_LISTED");
+
+        /* Checks: the zero edge case. */
+        require(newDebtCeiling > 0, "ERR_SET_BOND_DEBT_CEILING_ZERO");
+
+        /* Effects: update storage. */
+        uint256 oldDebtCeiling = bonds[fyToken].debtCeiling;
+        bonds[fyToken].debtCeiling = newDebtCeiling;
+
+        emit SetBondDebtCeiling(admin, fyToken, oldDebtCeiling, newDebtCeiling);
+
+        return true;
+    }
+
+    /**
      * @notice Updates the state of the permission accessed by the fyToken before a borrow.
      *
      * @dev Emits a {SetBorrowAllowed} event.
@@ -250,42 +286,6 @@ contract Fintroller is
             oldCollateralizationRatioMantissa,
             newCollateralizationRatioMantissa
         );
-
-        return true;
-    }
-
-    /**
-     * @notice Updates the debt ceiling, which limits how much debt can be created in the bond market.
-     *
-     * @dev Emits a {SetDebtCeiling} event.
-     *
-     * Requirements:
-     *
-     * - The caller must be the administrator.
-     * - The bond must be listed.
-     * - The debt ceiling cannot be zero.
-     *
-     * @param fyToken The bond for which to update the debt ceiling.
-     * @param newDebtCeiling The uint256 value of the new debt ceiling, specified in the bond's decimal system.
-     * @return bool true = success, otherwise it reverts.
-     */
-    function setDebtCeiling(FyTokenInterface fyToken, uint256 newDebtCeiling)
-        external
-        override
-        onlyAdmin
-        returns (bool)
-    {
-        /* Checks: bond is listed. */
-        require(bonds[fyToken].isListed, "ERR_BOND_NOT_LISTED");
-
-        /* Checks: the zero edge case. */
-        require(newDebtCeiling > 0, "ERR_SET_DEBT_CEILING_ZERO");
-
-        /* Effects: update storage. */
-        uint256 oldDebtCeiling = bonds[fyToken].debtCeiling;
-        bonds[fyToken].debtCeiling = newDebtCeiling;
-
-        emit SetDebtCeiling(admin, fyToken, oldDebtCeiling, newDebtCeiling);
 
         return true;
     }

--- a/contracts/Fintroller.sol
+++ b/contracts/Fintroller.sol
@@ -195,6 +195,7 @@ contract Fintroller is
      * - The caller must be the administrator.
      * - The bond must be listed.
      * - The debt ceiling cannot be zero.
+     * - The debt ceiling cannot fall below the current total supply of fyTokens.
      *
      * @param fyToken The bond for which to update the debt ceiling.
      * @param newDebtCeiling The uint256 value of the new debt ceiling, specified in the bond's decimal system.
@@ -211,6 +212,10 @@ contract Fintroller is
 
         /* Checks: the zero edge case. */
         require(newDebtCeiling > 0, "ERR_SET_BOND_DEBT_CEILING_ZERO");
+
+        /* Checks: above total supply of fyTokens. */
+        uint256 totalSupply = Erc20Interface(address(fyToken)).totalSupply();
+        require(newDebtCeiling >= totalSupply, "ERR_SET_BOND_DEBT_CEILING_UNDERFLOW");
 
         /* Effects: update storage. */
         uint256 oldDebtCeiling = bonds[fyToken].debtCeiling;

--- a/contracts/Fintroller.sol
+++ b/contracts/Fintroller.sol
@@ -163,12 +163,13 @@ contract Fintroller is
      * Requirements:
      *
      * - The caller must be the administrator.
+     * - The fyToken must pass the inspection.
      *
      * @param fyToken The fyToken contract to list.
      * @return bool true = success, otherwise it reverts.
      */
     function listBond(FyTokenInterface fyToken) external override onlyAdmin returns (bool) {
-        fyToken.isFyToken();
+        require(fyToken.isFyToken(), "ERR_LIST_BOND_FYTOKEN_INSPECTION");
         bonds[fyToken] = Bond({
             collateralizationRatio: Exp({ mantissa: defaultCollateralizationRatioMantissa }),
             debtCeiling: 0,

--- a/contracts/Fintroller.sol
+++ b/contracts/Fintroller.sol
@@ -60,16 +60,6 @@ contract Fintroller is
     }
 
     /**
-     * @notice Reads the debt ceiling of the given bond.
-     * @dev It is not an error to provide an invalid fyToken address.
-     * @param fyToken The address of the bond contract.
-     * @return The debt ceiling as a uint256, or zero if an invalid address was provided.
-     */
-    function getBondDebtCeiling(FyTokenInterface fyToken) external view override returns (uint256) {
-        return bonds[fyToken].debtCeiling;
-    }
-
-    /**
      * @notice Reads the collateralization ratio of the given bond.
      * @dev It is not an error to provide an invalid fyToken address.
      * @param fyToken The address of the bond contract.
@@ -80,8 +70,18 @@ contract Fintroller is
     }
 
     /**
+     * @notice Reads the debt ceiling of the given bond.
+     * @dev It is not an error to provide an invalid fyToken address.
+     * @param fyToken The address of the bond contract.
+     * @return The debt ceiling as a uint256, or zero if an invalid address was provided.
+     */
+    function getBondDebtCeiling(FyTokenInterface fyToken) external view override returns (uint256) {
+        return bonds[fyToken].debtCeiling;
+    }
+
+    /**
      * @notice Check if the account should be allowed to borrow fyTokens.
-     * @dev Reverts it the bond is not listed.
+     * @dev The bond must be listed.
      * @param fyToken The bond to make the check against.
      * @return bool true = allowed, false = not allowed.
      */
@@ -93,7 +93,7 @@ contract Fintroller is
 
     /**
      * @notice Checks if the account should be allowed to deposit collateral.
-     * @dev Reverts it the bond is not listed.
+     * @dev The bond must be listed.
      * @param fyToken The bond to make the check against.
      * @return bool true = allowed, false = not allowed.
      */
@@ -105,7 +105,7 @@ contract Fintroller is
 
     /**
      * @notice Check if the account should be allowed to liquidate fyToken borrows.
-     * @dev Reverts it the bond is not listed.
+     * @dev The bond must be listed.
      * @param fyToken The bond to make the check against.
      * @return bool true = allowed, false = not allowed.
      */
@@ -117,7 +117,7 @@ contract Fintroller is
 
     /**
      * @notice Checks if the account should be allowed to redeem the underlying asset from the Redemption Pool.
-     * @dev Reverts it the bond is not listed.
+     * @dev The bond must be listed.
      * @param fyToken The bond to make the check against.
      * @return bool true = allowed, false = not allowed.
      */
@@ -129,7 +129,7 @@ contract Fintroller is
 
     /**
      * @notice Checks if the account should be allowed to repay borrows.
-     * @dev Reverts it the bond is not listed.
+     * @dev The bond must be listed.
      * @param fyToken The bond to make the check against.
      * @return bool true = allowed, false = not allowed.
      */
@@ -141,7 +141,7 @@ contract Fintroller is
 
     /**
      * @notice Checks if the account should be allowed to the supply underlying asset to the Redemption Pool.
-     * @dev Reverts it the bond is not listed.
+     * @dev The bond must be listed.
      * @param fyToken The bond to make the check against.
      * @return bool true = allowed, false = not allowed.
      */

--- a/contracts/Fintroller.sol
+++ b/contracts/Fintroller.sol
@@ -344,14 +344,14 @@ contract Fintroller is
     }
 
     /**
-     * @notice Lorem ipsum.
+     * @notice Sets a new value for the liquidation incentive, which is applicable
+     * to all listed bonds.
      *
      * @dev Emits a {SetLiquidationIncentive} event.
      *
      * Requirements:
      *
      * - The caller must be the administrator.
-     * - The bond must be listed.
      * - The new liquidation incentive cannot be higher than the maximum liquidation incentive.
      * - The new liquidation incentive cannot be lower than the minimum liquidation incentive.
 

--- a/contracts/FintrollerInterface.sol
+++ b/contracts/FintrollerInterface.sol
@@ -47,14 +47,14 @@ abstract contract FintrollerInterface is FintrollerStorage {
 
     function listBond(FyTokenInterface fyToken) external virtual returns (bool);
 
+    function setBondDebtCeiling(FyTokenInterface fyToken, uint256 newDebtCeiling) external virtual returns (bool);
+
     function setBorrowAllowed(FyTokenInterface fyToken, bool state) external virtual returns (bool);
 
     function setCollateralizationRatio(FyTokenInterface fyToken, uint256 newCollateralizationRatioMantissa)
         external
         virtual
         returns (bool);
-
-    function setDebtCeiling(FyTokenInterface fyToken, uint256 newDebtCeiling) external virtual returns (bool);
 
     function setDepositCollateralAllowed(FyTokenInterface fyToken, bool state) external virtual returns (bool);
 
@@ -84,7 +84,7 @@ abstract contract FintrollerInterface is FintrollerStorage {
         uint256 newCollateralizationRatio
     );
 
-    event SetDebtCeiling(
+    event SetBondDebtCeiling(
         address indexed admin,
         FyTokenInterface indexed fyToken,
         uint256 oldDebtCeiling,

--- a/contracts/FintrollerInterface.sol
+++ b/contracts/FintrollerInterface.sol
@@ -27,9 +27,9 @@ abstract contract FintrollerInterface is FintrollerStorage {
 
     function getBorrowAllowed(FyTokenInterface fyToken) external view virtual returns (bool);
 
-    function getBondDebtCeiling(FyTokenInterface fyToken) external view virtual returns (uint256);
-
     function getBondCollateralizationRatio(FyTokenInterface fyToken) external view virtual returns (uint256);
+
+    function getBondDebtCeiling(FyTokenInterface fyToken) external view virtual returns (uint256);
 
     function getDepositCollateralAllowed(FyTokenInterface fyToken) external view virtual returns (bool);
 

--- a/contracts/FyToken.sol
+++ b/contracts/FyToken.sol
@@ -138,7 +138,7 @@ contract FyToken is
         vars.debtCeiling = fintroller.getBondDebtCeiling(this);
         require(vars.hypotheticalTotalSupply <= vars.debtCeiling, "ERR_BORROW_DEBT_CEILING_OVERFLOW");
 
-        /* Add the borrow amount to the account's current debt. */
+        /* Add the borrow amount to the borrower account's current debt. */
         (vars.debt, , vars.lockedCollateral, ) = balanceSheet.getVault(this, msg.sender);
         require(vars.lockedCollateral > 0, "ERR_BORROW_LOCKED_COLLATERAL_ZERO");
         (vars.mathErr, vars.newDebt) = addUInt(vars.debt, borrowAmount);
@@ -160,7 +160,7 @@ contract FyToken is
         /* Effects: print the new fyTokens into existence. */
         mintInternal(msg.sender, borrowAmount);
 
-        /* Interactions: increase the debt of the account. */
+        /* Interactions: increase the debt of the borrower account. */
         require(balanceSheet.setVaultDebt(this, msg.sender, vars.newDebt), "ERR_BORROW_CALL_SET_VAULT_DEBT");
 
         /* Emit a Borrow, Mint and Transfer event. */
@@ -277,7 +277,7 @@ contract FyToken is
      * - Can only be called by the Redemption Pool.
      * - The amount to mint cannot be zero.
      *
-     * @param beneficiary The account for which to mint the tokens.
+     * @param beneficiary The borrower account for which to mint the tokens.
      * @param mintAmount The amount of fyTokens to print into existence.
      * @return bool true = success, otherwise it reverts.
      */
@@ -295,7 +295,9 @@ contract FyToken is
     }
 
     /**
-     * @notice Deletes the account's debt from the registry and take the fyTokens out of circulation.
+     * @notice Deletes the borrower account's debt from the registry and take the fyTokens
+     * out of circulation.
+     *
      * @dev Emits a {Burn}, {Transfer} and {RepayBorrow} event.
      *
      * Requirements:
@@ -315,13 +317,15 @@ contract FyToken is
     }
 
     /**
-     * @notice Clears the borrower's debt from the registry and take the fyTokens out of circulation.
+     * @notice Clears the borrower account's debt from the registry and take the fyTokens
+     * out of circulation.
+     *
      * @dev Emits a {Burn}, {Transfer} and {RepayBorrow} event.
      *
      * Requirements: same as the `repayBorrow` function, but here `borrower` is the account that must
      * have at least `repayAmount` fyTokens to repay the borrow.
      *
-     * @param borrower The account for which to repay the borrow.
+     * @param borrower The borrower account for which to repay the borrow.
      * @param repayAmount The amount of fyTokens to repay.
      * @return true = success, otherwise it reverts.
      */

--- a/contracts/FyToken.sol
+++ b/contracts/FyToken.sol
@@ -350,13 +350,14 @@ contract FyToken is
      * Requirements:
      *
      * - The caller must be the administrator.
+     * - The new Fintroller must pass the inspection.
      *
-     * @param newFintroller The address of the Fintroller contract.
+     * @param newFintroller The address of the new Fintroller contract.
      * @return bool true = success, otherwise it reverts.
      */
     function _setFintroller(FintrollerInterface newFintroller) external override onlyAdmin returns (bool) {
         /* Checks: sanity check the new Fintroller contract. */
-        newFintroller.isFintroller();
+        require(newFintroller.isFintroller(), "ERR_SET_FINTROLLER_INSPECTION");
 
         /* Effects: update storage. */
         FintrollerInterface oldFintroller = fintroller;

--- a/contracts/FyToken.sol
+++ b/contracts/FyToken.sol
@@ -160,12 +160,14 @@ contract FyToken is
         /* Effects: print the new fyTokens into existence. */
         mintInternal(msg.sender, borrowAmount);
 
+        /* Emit a Transfer and a Borrow event. */
+        emit Transfer(address(this), msg.sender, borrowAmount);
+
         /* Interactions: increase the debt of the borrower account. */
         require(balanceSheet.setVaultDebt(this, msg.sender, vars.newDebt), "ERR_BORROW_CALL_SET_VAULT_DEBT");
 
-        /* Emit a Borrow, Mint and Transfer event. */
+        /* Emit a Borrow event. */
         emit Borrow(msg.sender, borrowAmount);
-        emit Transfer(address(this), msg.sender, borrowAmount);
 
         return true;
     }
@@ -400,6 +402,9 @@ contract FyToken is
         /* Effects: burn the fyTokens. */
         burnInternal(payer, repayAmount);
 
+        /* Emit a Transfer event. */
+        emit Transfer(payer, address(this), repayAmount);
+
         /* Calculate the new debt of the borrower. */
         MathError mathErr;
         uint256 newDebt;
@@ -410,8 +415,7 @@ contract FyToken is
         /* Interactions: reduce the debt of the borrower . */
         require(balanceSheet.setVaultDebt(this, borrower, newDebt), "ERR_REPAY_BORROW_CALL_SET_VAULT_DEBT");
 
-        /* Emit both a Transfer and a RepayBorrow event. */
-        emit Transfer(payer, address(this), repayAmount);
+        /* Emit both a RepayBorrow event. */
         emit RepayBorrow(payer, borrower, repayAmount, newDebt);
     }
 }

--- a/contracts/FyToken.sol
+++ b/contracts/FyToken.sol
@@ -310,7 +310,7 @@ contract FyToken is
      * - The caller must have at least `repayAmount` fyTokens.
      * - The caller must have at least `repayAmount` debt.
      *
-     * @param repayAmount Lorem ipsum.
+     * @param repayAmount The amount of fyTokens to repay.
      * @return true = success, otherwise it reverts.
      */
     function repayBorrow(uint256 repayAmount) external override isVaultOpen(msg.sender) nonReentrant returns (bool) {

--- a/contracts/FyTokenInterface.sol
+++ b/contracts/FyTokenInterface.sol
@@ -17,7 +17,7 @@ abstract contract FyTokenInterface is FyTokenStorage {
 
     function liquidateBorrow(address borrower, uint256 repayAmount) external virtual returns (bool);
 
-    function mint(address beneficiary, uint256 borrowAmount) external virtual returns (bool);
+    function mint(address beneficiary, uint256 mintAmount) external virtual returns (bool);
 
     function repayBorrow(uint256 repayAmount) external virtual returns (bool);
 
@@ -28,7 +28,7 @@ abstract contract FyTokenInterface is FyTokenStorage {
     /**
      * EVENTS
      */
-    event Borrow(address indexed account, uint256 repayAmount);
+    event Borrow(address indexed borrower, uint256 borrowAmount);
 
     event LiquidateBorrow(
         address indexed liquidator,

--- a/contracts/FyTokenStorage.sol
+++ b/contracts/FyTokenStorage.sol
@@ -12,16 +12,6 @@ import "./RedemptionPoolInterface.sol";
  */
 abstract contract FyTokenStorage {
     /**
-     * STRUCTS
-     */
-    struct Vault {
-        uint256 debt;
-        uint256 freeCollateral;
-        uint256 lockedCollateral;
-        bool isOpen;
-    }
-
-    /**
      * STORAGE PROPERTIES
      */
 

--- a/contracts/invariants/BaseInvariants.sol
+++ b/contracts/invariants/BaseInvariants.sol
@@ -3,5 +3,5 @@ pragma solidity ^0.7.0;
 
 abstract contract BaseInvariants {
     address private constant deployer = address(0x1000);
-    address private constant caller1 = address(0x20000);
+    address private constant caller1 = address(0x2000);
 }

--- a/contracts/test/GodModeBalanceSheet.sol
+++ b/contracts/test/GodModeBalanceSheet.sol
@@ -15,33 +15,33 @@ contract GodModeBalanceSheet is BalanceSheet {
 
     function __godMode_setVaultDebt(
         FyTokenInterface fyToken,
-        address account,
+        address borrower,
         uint256 newVaultDebt
     ) external {
-        vaults[address(fyToken)][account].debt = newVaultDebt;
+        vaults[address(fyToken)][borrower].debt = newVaultDebt;
     }
 
     function __godMode_setVaultFreeCollateral(
         FyTokenInterface fyToken,
-        address account,
+        address borrower,
         uint256 newFreeCollateral
     ) external {
-        vaults[address(fyToken)][account].freeCollateral = newFreeCollateral;
+        vaults[address(fyToken)][borrower].freeCollateral = newFreeCollateral;
     }
 
     function __godMode_setVaultLockedCollateral(
         FyTokenInterface fyToken,
-        address account,
+        address borrower,
         uint256 newLockedCollateral
     ) external {
-        vaults[address(fyToken)][account].lockedCollateral = newLockedCollateral;
+        vaults[address(fyToken)][borrower].lockedCollateral = newLockedCollateral;
     }
 
     function __godMode_setVaultIsOpen(
         FyTokenInterface fyToken,
-        address account,
+        address borrower,
         bool newIsOpen
     ) external {
-        vaults[address(fyToken)][account].isOpen = newIsOpen;
+        vaults[address(fyToken)][borrower].isOpen = newIsOpen;
     }
 }

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -4,51 +4,28 @@ export enum AdminErrors {
 
 export enum BalanceSheetErrors {
   ClutchCollateralNotAuthorized = "ERR_CLUTCH_COLLATERAL_NOT_AUTHORIZED",
-  DepositCollateralZero = "ERR_DEPOSIT_COLLATERAL_ZERO",
   DepositCollateralNotAllowed = "ERR_DEPOSIT_COLLATERAL_NOT_ALLOWED",
+  DepositCollateralZero = "ERR_DEPOSIT_COLLATERAL_ZERO",
   FreeCollateralZero = "ERR_FREE_COLLATERAL_ZERO",
   GetClutchableCollateralZero = "ERR_GET_CLUTCHABLE_COLLATERAL_ZERO",
   GetHypotheticalCollateralizationRatioDebtZero = "ERR_GET_HYPOTHETICAL_COLLATERALIZATION_RATIO_DEBT_ZERO",
   InsufficientFreeCollateral = "ERR_INSUFFICIENT_FREE_COLLATERAL",
   InsufficientLockedCollateral = "ERR_INSUFFICIENT_LOCKED_COLLATERAL",
   LockCollateralZero = "ERR_LOCK_COLLATERAL_ZERO",
+  OpenVaultFyTokenInspection = "ERR_OPEN_VAULT_FYTOKEN_INSPECTION",
   SetVaultDebtNotAuthorized = "ERR_SET_VAULT_DEBT_NOT_AUTHORIZED",
   WithdrawCollateralZero = "ERR_WITHDRAW_COLLATERAL_ZERO",
 }
 
-export enum Erc20PermitErrors {
-  Expired = "ERR_ERC20_PERMIT_EXPIRED",
-  InvalidSignature = "ERR_ERC20_PERMIT_INVALID_SIGNATURE",
-  OwnerZeroAddress = "ERR_ERC20_PERMIT_OWNER_ZERO_ADDRESS",
-  RecoveredOwnerZeroAddress = "ERR_ERC20_PERMIT_RECOVERED_OWNER_ZERO_ADDRESS",
-  SpenderZeroAddress = "ERR_ERC20_PERMIT_SPENDER_ZERO_ADDRESS",
-}
-
 export enum FintrollerErrors {
   BondNotListed = "ERR_BOND_NOT_LISTED",
+  ListBondFyTokenInspection = "ERR_LIST_BOND_FYTOKEN_INSPECTION",
   SetBondDebtCeilingZero = "ERR_SET_BOND_DEBT_CEILING_ZERO",
   SetCollateralizationRatioLowerBound = "ERR_SET_COLLATERALIZATION_RATIO_LOWER_BOUND",
   SetCollateralizationRatioUpperBound = "ERR_SET_COLLATERALIZATION_RATIO_UPPER_BOUND",
   SetLiquidationIncentiveLowerBound = "ERR_SET_LIQUIDATION_INCENTIVE_LOWER_BOUND",
   SetLiquidationIncentiveUpperBound = "ERR_SET_LIQUIDATION_INCENTIVE_UPPER_BOUND",
   SetOracleZeroAddress = "ERR_SET_ORACLE_ZERO_ADDRESS",
-}
-
-export enum GenericErrors {
-  AccountNotUnderwater = "ERR_ACCOUNT_NOT_UNDERWATER",
-  BelowCollateralizationRatio = "ERR_BELOW_COLLATERALIZATION_RATIO",
-  BondMatured = "ERR_BOND_MATURED",
-  BondNotMatured = "ERR_BOND_NOT_MATURED",
-  Initialized = "ERR_INITALIZED",
-  NotInitialized = "ERR_NOT_INITALIZED",
-  VaultOpen = "ERR_VAULT_OPEN",
-  VaultNotOpen = "ERR_VAULT_NOT_OPEN",
-}
-
-export enum Erc20RecoverErrors {
-  RecoverZero = "ERR_RECOVER_ZERO",
-  RecoverNonRecoverableToken = "ERR_RECOVER_NON_RECOVERABLE_TOKEN",
-  SetNonRecoverableTokensEmptyArray = "ERR_SET_NON_RECOVERABLE_TOKENS_EMPTY_ARRAY",
 }
 
 export enum FyTokenErrors {
@@ -72,6 +49,17 @@ export enum FyTokenErrors {
   RepayBorrowInsufficientDebt = "ERR_REPAY_BORROW_INSUFFICIENT_DEBT",
   RepayBorrowNotAllowed = "ERR_REPAY_BORROW_NOT_ALLOWED",
   RepayBorrowZero = "ERR_REPAY_BORROW_ZERO",
+  SetFintrollerInspection = "ERR_SET_FINTROLLER_INSPECTION",
+}
+
+export enum GenericErrors {
+  AccountNotUnderwater = "ERR_ACCOUNT_NOT_UNDERWATER",
+  BelowCollateralizationRatio = "ERR_BELOW_COLLATERALIZATION_RATIO",
+  BondMatured = "ERR_BOND_MATURED",
+  BondNotMatured = "ERR_BOND_NOT_MATURED",
+  NotInitialized = "ERR_NOT_INITALIZED",
+  VaultOpen = "ERR_VAULT_OPEN",
+  VaultNotOpen = "ERR_VAULT_NOT_OPEN",
 }
 
 export enum OraclePriceUtilsErrors {

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -20,6 +20,7 @@ export enum BalanceSheetErrors {
 export enum FintrollerErrors {
   BondNotListed = "ERR_BOND_NOT_LISTED",
   ListBondFyTokenInspection = "ERR_LIST_BOND_FYTOKEN_INSPECTION",
+  SetBondDebtCeilingUnderflow = "ERR_SET_BOND_DEBT_CEILING_UNDERFLOW",
   SetBondDebtCeilingZero = "ERR_SET_BOND_DEBT_CEILING_ZERO",
   SetCollateralizationRatioLowerBound = "ERR_SET_COLLATERALIZATION_RATIO_LOWER_BOUND",
   SetCollateralizationRatioUpperBound = "ERR_SET_COLLATERALIZATION_RATIO_UPPER_BOUND",

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -26,9 +26,9 @@ export enum Erc20PermitErrors {
 
 export enum FintrollerErrors {
   BondNotListed = "ERR_BOND_NOT_LISTED",
+  SetBondDebtCeilingZero = "ERR_SET_BOND_DEBT_CEILING_ZERO",
   SetCollateralizationRatioLowerBound = "ERR_SET_COLLATERALIZATION_RATIO_LOWER_BOUND",
   SetCollateralizationRatioUpperBound = "ERR_SET_COLLATERALIZATION_RATIO_UPPER_BOUND",
-  SetDebtCeilingZero = "ERR_SET_DEBT_CEILING_ZERO",
   SetLiquidationIncentiveLowerBound = "ERR_SET_LIQUIDATION_INCENTIVE_LOWER_BOUND",
   SetLiquidationIncentiveUpperBound = "ERR_SET_LIQUIDATION_INCENTIVE_UPPER_BOUND",
   SetOracleZeroAddress = "ERR_SET_ORACLE_ZERO_ADDRESS",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/mainframehq/mainframe-lending-protocol/issues"
   },
+  "dependencies": {
+    "@paulrberg/contracts": "1.2.2"
+  },
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^9.1.2",
@@ -27,7 +30,6 @@
     "@nomiclabs/buidler": "1.4.8",
     "@nomiclabs/buidler-ethers": "^2.0.0",
     "@nomiclabs/buidler-waffle": "^2.1.0",
-    "@paulrberg/contracts": "1.2.1",
     "@typechain/ethers-v5": "^1.0.0",
     "@types/chai": "^4.2.12",
     "@types/fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/mainframehq/mainframe-lending-protocol/issues"
   },
   "dependencies": {
-    "@paulrberg/contracts": "1.2.2"
+    "@paulrberg/contracts": "1.3.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",

--- a/test/integration/fyToken/effects/borrow.ts
+++ b/test/integration/fyToken/effects/borrow.ts
@@ -21,7 +21,7 @@ export default function shouldBehaveLikeBorrow(): void {
     /* Set the debt ceiling to 1,000 fyDAI. */
     await this.contracts.fintroller
       .connect(this.signers.admin)
-      .setDebtCeiling(this.contracts.fyToken.address, tokenAmounts.oneHundredThousand);
+      .setBondDebtCeiling(this.contracts.fyToken.address, tokenAmounts.oneHundredThousand);
 
     /* Mint 10 WETH and approve the Balance Sheet to spend it all. */
     await this.contracts.collateral.mint(this.accounts.borrower, collateralAmount);

--- a/test/integration/fyToken/effects/liquidateBorrow.ts
+++ b/test/integration/fyToken/effects/liquidateBorrow.ts
@@ -31,7 +31,7 @@ export default function shouldBehaveLikeLiquidateBorrow(): void {
     /* Set the debt ceiling to 1,000 fyDAI. */
     await this.contracts.fintroller
       .connect(this.signers.admin)
-      .setDebtCeiling(this.contracts.fyToken.address, tokenAmounts.oneHundredThousand);
+      .setBondDebtCeiling(this.contracts.fyToken.address, tokenAmounts.oneHundredThousand);
 
     /* Set the liquidation incentive to 110%. */
     await this.contracts.fintroller.connect(this.signers.admin).setLiquidationIncentive(percentages.oneHundredAndTen);

--- a/test/integration/fyToken/effects/repayBorrow.ts
+++ b/test/integration/fyToken/effects/repayBorrow.ts
@@ -24,7 +24,7 @@ export default function shouldBehaveLikeLiquidateBorrow(): void {
     /* Set the debt ceiling to 1,000 yDAI. */
     await this.contracts.fintroller
       .connect(this.signers.admin)
-      .setDebtCeiling(this.contracts.fyToken.address, tokenAmounts.oneHundredThousand);
+      .setBondDebtCeiling(this.contracts.fyToken.address, tokenAmounts.oneHundredThousand);
 
     /* Mint 10 WETH and approve the Balance Sheet to spend it all. */
     await this.contracts.collateral.mint(this.accounts.borrower, collateralAmount);

--- a/test/integration/redemptionPool/effects/redeemFyTokens.ts
+++ b/test/integration/redemptionPool/effects/redeemFyTokens.ts
@@ -1,11 +1,10 @@
 import { BigNumber } from "@ethersproject/bignumber";
-import { tokenAmounts } from "../../../../helpers/constants";
-
 import { expect } from "chai";
 
-import { fyTokenConstants } from "../../../../helpers/constants";
 import { contextForTimeDependentTests } from "../../../contexts";
+import { fyTokenConstants } from "../../../../helpers/constants";
 import { increaseTime } from "../../../jsonRpc";
+import { tokenAmounts } from "../../../../helpers/constants";
 
 export default function shouldBehaveLikeSupplyUnderlying(): void {
   const underlyingAmount: BigNumber = tokenAmounts.oneHundred;

--- a/test/unit/balanceSheet/BalanceSheet.ts
+++ b/test/unit/balanceSheet/BalanceSheet.ts
@@ -1,5 +1,5 @@
-import { unitFixtureBalanceSheet } from "../fixtures";
 import { shouldBehaveLikeBalanceSheet } from "./BalanceSheet.behavior";
+import { unitFixtureBalanceSheet } from "../fixtures";
 
 export function unitTestBalanceSheet(): void {
   describe("BalanceSheet", function () {

--- a/test/unit/balanceSheet/effects/openVault.ts
+++ b/test/unit/balanceSheet/effects/openVault.ts
@@ -1,7 +1,6 @@
-import { AddressZero } from "@ethersproject/constants";
 import { expect } from "chai";
 
-import { GenericErrors } from "../../../../helpers/errors";
+import { BalanceSheetErrors, GenericErrors } from "../../../../helpers/errors";
 
 export default function shouldBehaveLikeOpenVault(): void {
   describe("when the vault is open", function () {
@@ -18,8 +17,14 @@ export default function shouldBehaveLikeOpenVault(): void {
 
   describe("when the vault is not open", function () {
     describe("when the fyToken is not compliant", function () {
+      beforeEach(async function () {
+        await this.stubs.fyToken.mock.isFyToken.returns(false);
+      });
+
       it("reverts", async function () {
-        await expect(this.contracts.balanceSheet.connect(this.signers.borrower).openVault(AddressZero)).to.be.reverted;
+        await expect(
+          this.contracts.balanceSheet.connect(this.signers.borrower).openVault(this.stubs.fyToken.address),
+        ).to.be.revertedWith(BalanceSheetErrors.OpenVaultFyTokenInspection);
       });
     });
 

--- a/test/unit/fintroller/Fintroller.behavior.ts
+++ b/test/unit/fintroller/Fintroller.behavior.ts
@@ -13,9 +13,9 @@ import shouldBehaveLikeOracleGetter from "./view/oracle";
 import shouldBehaveLikeOraclePricePrecisionScalarGetter from "./view/oraclePricePrecisionScalar";
 
 import shouldBehaveLikeListBond from "./effects/listBond";
+import shouldBehaveLikeSetBondDebtCeiling from "./effects/setBondDebtCeiling";
 import shouldBehaveLikeSetBorrowAllowed from "./effects/setBorrowAllowed";
 import shouldBehaveLikeSetCollateralizationRatio from "./effects/setCollateralizationRatio";
-import shouldBehaveLikeSetDebtCeiling from "./effects/setDebtCeiling";
 import shouldBehaveLikeSetDepositCollateralAllowed from "./effects/setDepositCollateralAllowed";
 import shouldBehaveLikeSetLiquidateBorrowAllowed from "./effects/setLiquidateBorrowAllowed";
 import shouldBehaveLikeSetLiquidationIncentive from "./effects/setLiquidationIncentive";
@@ -84,16 +84,16 @@ export function shouldBehaveLikeFintroller(): void {
       shouldBehaveLikeListBond();
     });
 
+    describe("setBondDebtCeiling", function () {
+      shouldBehaveLikeSetBondDebtCeiling();
+    });
+
     describe("setBorrowAllowed", function () {
       shouldBehaveLikeSetBorrowAllowed();
     });
 
     describe("setCollateralizationRatio", function () {
       shouldBehaveLikeSetCollateralizationRatio();
-    });
-
-    describe("setDebtCeiling", function () {
-      shouldBehaveLikeSetDebtCeiling();
     });
 
     describe("setDepositCollateralAllowed", function () {

--- a/test/unit/fintroller/Fintroller.ts
+++ b/test/unit/fintroller/Fintroller.ts
@@ -1,5 +1,5 @@
-import { unitFixtureFintroller } from "../fixtures";
 import { shouldBehaveLikeFintroller } from "./Fintroller.behavior";
+import { unitFixtureFintroller } from "../fixtures";
 
 export function unitTestFintroller(): void {
   describe("Fintroller", function () {

--- a/test/unit/fintroller/effects/listBond.ts
+++ b/test/unit/fintroller/effects/listBond.ts
@@ -1,7 +1,6 @@
-import { AddressZero } from "@ethersproject/constants";
 import { expect } from "chai";
 
-import { AdminErrors } from "../../../../helpers/errors";
+import { AdminErrors, FintrollerErrors } from "../../../../helpers/errors";
 
 export default function shouldBehaveLikeListBond(): void {
   describe("when the caller is not the admin", function () {
@@ -14,8 +13,14 @@ export default function shouldBehaveLikeListBond(): void {
 
   describe("when the caller is the admin", function () {
     describe("when the contract to be listed is non-compliant", function () {
+      beforeEach(async function () {
+        await this.stubs.fyToken.mock.isFyToken.returns(false);
+      });
+
       it("rejects", async function () {
-        await expect(this.contracts.fintroller.connect(this.signers.admin).listBond(AddressZero)).to.be.reverted;
+        await expect(
+          this.contracts.fintroller.connect(this.signers.admin).listBond(this.stubs.fyToken.address),
+        ).to.be.revertedWith(FintrollerErrors.ListBondFyTokenInspection);
       });
     });
 

--- a/test/unit/fintroller/effects/setBondDebtCeiling.ts
+++ b/test/unit/fintroller/effects/setBondDebtCeiling.ts
@@ -13,7 +13,7 @@ export default function shouldBehaveLikeSetDebtCeiling(): void {
       await expect(
         this.contracts.fintroller
           .connect(this.signers.raider)
-          .setDebtCeiling(this.stubs.fyToken.address, newDebtCeiling),
+          .setBondDebtCeiling(this.stubs.fyToken.address, newDebtCeiling),
       ).to.be.revertedWith(AdminErrors.NotAdmin);
     });
   });
@@ -24,7 +24,7 @@ export default function shouldBehaveLikeSetDebtCeiling(): void {
         await expect(
           this.contracts.fintroller
             .connect(this.signers.admin)
-            .setDebtCeiling(this.stubs.fyToken.address, newDebtCeiling),
+            .setBondDebtCeiling(this.stubs.fyToken.address, newDebtCeiling),
         ).to.be.revertedWith(FintrollerErrors.BondNotListed);
       });
     });
@@ -37,8 +37,8 @@ export default function shouldBehaveLikeSetDebtCeiling(): void {
       describe("when the debt ceiling is zero", function () {
         it("reverts", async function () {
           await expect(
-            this.contracts.fintroller.connect(this.signers.admin).setDebtCeiling(this.stubs.fyToken.address, Zero),
-          ).to.be.revertedWith(FintrollerErrors.SetDebtCeilingZero);
+            this.contracts.fintroller.connect(this.signers.admin).setBondDebtCeiling(this.stubs.fyToken.address, Zero),
+          ).to.be.revertedWith(FintrollerErrors.SetBondDebtCeilingZero);
         });
       });
 
@@ -46,20 +46,20 @@ export default function shouldBehaveLikeSetDebtCeiling(): void {
         it("sets the new debt ceiling", async function () {
           await this.contracts.fintroller
             .connect(this.signers.admin)
-            .setDebtCeiling(this.stubs.fyToken.address, newDebtCeiling);
+            .setBondDebtCeiling(this.stubs.fyToken.address, newDebtCeiling);
           const contractDebtCeiling: BigNumber = await this.contracts.fintroller.getBondDebtCeiling(
             this.stubs.fyToken.address,
           );
           expect(contractDebtCeiling).to.equal(newDebtCeiling);
         });
 
-        it("emits a SetDebtCeiling event", async function () {
+        it("emits a SetBondDebtCeiling event", async function () {
           await expect(
             this.contracts.fintroller
               .connect(this.signers.admin)
-              .setDebtCeiling(this.stubs.fyToken.address, newDebtCeiling),
+              .setBondDebtCeiling(this.stubs.fyToken.address, newDebtCeiling),
           )
-            .to.emit(this.contracts.fintroller, "SetDebtCeiling")
+            .to.emit(this.contracts.fintroller, "SetBondDebtCeiling")
             .withArgs(this.accounts.admin, this.stubs.fyToken.address, Zero, newDebtCeiling);
         });
       });

--- a/test/unit/fixtures.ts
+++ b/test/unit/fixtures.ts
@@ -54,7 +54,11 @@ export async function unitFixtureBalanceSheet(signers: Signer[]): Promise<UnitFi
   return { balanceSheet, collateral, fintroller, oracle, underlying, fyToken };
 }
 
-type UnitFixtureFintrollerReturnType = { fintroller: Fintroller; oracle: MockContract; fyToken: MockContract };
+type UnitFixtureFintrollerReturnType = {
+  fintroller: Fintroller;
+  oracle: MockContract;
+  fyToken: MockContract;
+};
 
 export async function unitFixtureFintroller(signers: Signer[]): Promise<UnitFixtureFintrollerReturnType> {
   const deployer: Signer = signers[0];

--- a/test/unit/fyToken/effects/borrow.ts
+++ b/test/unit/fyToken/effects/borrow.ts
@@ -2,10 +2,10 @@ import { BigNumber } from "@ethersproject/bignumber";
 import { Zero } from "@ethersproject/constants";
 import { expect } from "chai";
 
-import { fintrollerConstants, percentages, tokenAmounts } from "../../../../helpers/constants";
 import { FintrollerErrors, FyTokenErrors, GenericErrors } from "../../../../helpers/errors";
-import { fyTokenConstants } from "../../../../helpers/constants";
 import { contextForTimeDependentTests } from "../../../contexts";
+import { fintrollerConstants, percentages, tokenAmounts } from "../../../../helpers/constants";
+import { fyTokenConstants } from "../../../../helpers/constants";
 import { increaseTime } from "../../../jsonRpc";
 import { stubIsVaultOpen, stubVaultFreeCollateral, stubVaultLockedCollateral } from "../../stubs";
 

--- a/test/unit/fyToken/effects/liquidateBorrow.ts
+++ b/test/unit/fyToken/effects/liquidateBorrow.ts
@@ -2,9 +2,9 @@ import { BigNumber } from "@ethersproject/bignumber";
 import { Zero } from "@ethersproject/constants";
 import { expect } from "chai";
 
-import { fintrollerConstants, fyTokenConstants, tokenAmounts } from "../../../../helpers/constants";
 import { FintrollerErrors, FyTokenErrors, GenericErrors } from "../../../../helpers/errors";
 import { contextForTimeDependentTests } from "../../../contexts";
+import { fintrollerConstants, fyTokenConstants, tokenAmounts } from "../../../../helpers/constants";
 import { increaseTime } from "../../../jsonRpc";
 import { stubIsVaultOpen } from "../../stubs";
 

--- a/test/unit/fyToken/effects/repayBorrow.ts
+++ b/test/unit/fyToken/effects/repayBorrow.ts
@@ -2,9 +2,9 @@ import { Zero } from "@ethersproject/constants";
 import { BigNumber } from "@ethersproject/bignumber";
 import { expect } from "chai";
 
-import { addressOne, fintrollerConstants, tokenAmounts } from "../../../../helpers/constants";
 import { FyTokenErrors, GenericErrors } from "../../../../helpers/errors";
 import { FintrollerErrors } from "../../../../helpers/errors";
+import { addressOne, fintrollerConstants, tokenAmounts } from "../../../../helpers/constants";
 import { stubIsVaultOpen } from "../../stubs";
 
 export default function shouldBehaveLikeRepayBorrow(): void {

--- a/test/unit/fyToken/effects/setFintroller.ts
+++ b/test/unit/fyToken/effects/setFintroller.ts
@@ -1,34 +1,44 @@
+import { AddressZero } from "@ethersproject/constants";
+import { MockContract } from "ethereum-waffle";
 import { expect } from "chai";
 
-import { addressOne } from "../../../../helpers/constants";
-import { AdminErrors } from "../../../../helpers/errors";
-import { Fintroller } from "../../../../typechain/Fintroller";
-import { deployFintroller } from "../../../deployers";
+import { AdminErrors, FyTokenErrors } from "../../../../helpers/errors";
+import { deployStubFintroller } from "../../stubs";
 
 export default function shouldBehaveLikeSetFintroller(): void {
   describe("when the caller is not the administrator", function () {
     it("reverts", async function () {
-      await expect(this.contracts.fyToken.connect(this.signers.raider)._setFintroller(addressOne)).to.be.revertedWith(
+      await expect(this.contracts.fyToken.connect(this.signers.raider)._setFintroller(AddressZero)).to.be.revertedWith(
         AdminErrors.NotAdmin,
       );
     });
   });
 
   describe("when the caller is the administrator", function () {
+    let newFintroller: MockContract;
+
+    beforeEach(async function () {
+      newFintroller = await deployStubFintroller(this.signers.admin);
+    });
+
     describe("when the new Fintroller is not compliant", function () {
+      beforeEach(async function () {
+        await newFintroller.mock.isFintroller.returns(false);
+      });
+
       it("reverts", async function () {
-        await expect(this.contracts.fyToken.connect(this.signers.admin)._setFintroller(addressOne)).to.be.reverted;
+        await expect(
+          this.contracts.fyToken.connect(this.signers.admin)._setFintroller(newFintroller.address),
+        ).to.be.revertedWith(FyTokenErrors.SetFintrollerInspection);
       });
     });
 
     describe("when the new Fintroller is compliant", function () {
-      let newFintroller: Fintroller;
-
       beforeEach(async function () {
-        newFintroller = await deployFintroller(this.signers.admin);
+        await newFintroller.mock.isFintroller.returns(true);
       });
 
-      it("reverts", async function () {
+      it("sets the new Fintroller", async function () {
         await this.contracts.fyToken.connect(this.signers.admin)._setFintroller(newFintroller.address);
         const newFintrollerAddress: string = await this.contracts.fyToken.fintroller();
         expect(newFintroller.address).to.equal(newFintrollerAddress);

--- a/test/unit/oraclePriceUtils/OraclePriceUtils.ts
+++ b/test/unit/oraclePriceUtils/OraclePriceUtils.ts
@@ -1,5 +1,5 @@
-import { unitFixtureOraclePriceUtils } from "../fixtures";
 import { shouldBehaveLikeOraclePriceUtils } from "./OraclePriceUtils.behavior";
+import { unitFixtureOraclePriceUtils } from "../fixtures";
 
 export function unitTestOraclePriceUtils(): void {
   describe("OraclePriceUtils", function () {

--- a/test/unit/redemptionPool/RedemptionPool.ts
+++ b/test/unit/redemptionPool/RedemptionPool.ts
@@ -1,5 +1,5 @@
-import { unitFixtureRedemptionPool } from "../fixtures";
 import { shouldBehaveLikeRedemptionPool } from "./RedemptionPool.behavior";
+import { unitFixtureRedemptionPool } from "../fixtures";
 
 export function unitTestRedemptionPool(): void {
   describe("RedemptionPool", function () {

--- a/test/unit/stubs.ts
+++ b/test/unit/stubs.ts
@@ -41,12 +41,12 @@ export async function deployStubErc20(
   symbol: string,
   decimals: BigNumber,
 ): Promise<MockContract> {
-  const collateral: MockContract = await deployStubContract(deployer, Erc20Artifact.abi);
-  await collateral.mock.name.returns(name);
-  await collateral.mock.symbol.returns(symbol);
-  await collateral.mock.decimals.returns(decimals);
-  await collateral.mock.totalSupply.returns(Zero);
-  return collateral;
+  const erc20: MockContract = await deployStubContract(deployer, Erc20Artifact.abi);
+  await erc20.mock.name.returns(name);
+  await erc20.mock.symbol.returns(symbol);
+  await erc20.mock.decimals.returns(decimals);
+  await erc20.mock.totalSupply.returns(Zero);
+  return erc20;
 }
 
 export async function deployStubFintroller(deployer: Signer): Promise<MockContract> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,10 +1007,10 @@
     safe-buffer "^5.1.1"
     util.promisify "^1.0.0"
 
-"@paulrberg/contracts@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/@paulrberg/contracts/-/contracts-1.2.2.tgz#04def5673dd907a687477b7b488c56c1982ff8aa"
-  integrity sha512-KGsT5o0PIXKWwyHPQSR03vhdsAGNTJfOdZR2gZs4kAgChzYmBwzgoILRKT75oX5ACRIN56PWmv0PAQAqramc6g==
+"@paulrberg/contracts@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@paulrberg/contracts/-/contracts-1.3.0.tgz#26302bd9a8eb65ead99728564c2a2431e8cceabc"
+  integrity sha512-x6TKANVfP5NVdyWLv8ZVeqn+1M1L+SG2eWYRUN2/A73TMz9nMkF/o6EJNyNKKpdEE5if83YcZHq4XxuWJdS+mg==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,10 +1007,10 @@
     safe-buffer "^5.1.1"
     util.promisify "^1.0.0"
 
-"@paulrberg/contracts@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/@paulrberg/contracts/-/contracts-1.2.1.tgz#8654271b16c2c749dc317496e55b7c4a04fc1625"
-  integrity sha512-AJWVW5foWo4FVmnByY3wEIo1EqsQd7O7Wrfzzk+1kootFXY12L5xjZCkEJziKgIWAAkSwWuEcrEbuoniLywqOQ==
+"@paulrberg/contracts@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/@paulrberg/contracts/-/contracts-1.2.2.tgz#04def5673dd907a687477b7b488c56c1982ff8aa"
+  integrity sha512-KGsT5o0PIXKWwyHPQSR03vhdsAGNTJfOdZR2gZs4kAgChzYmBwzgoILRKT75oX5ACRIN56PWmv0PAQAqramc6g==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
## Audit report

The audit has been made against commit [f77b7f3][1] of the current repository and commit [6c3ee4a][2] of [@paulrberg/contracts][3].

- [x] Resolve QSP-10 and wrap the calls to "isFyToken" and "isFintroller" in "require" statements
- [x] Resolve QSP-11
- [x] [Code documentation] Write function description on [line 346][4] of Fintroller.sol and [line 309][5] of FyToken.sol
- [x] [Adherence to best practices] Remove unimplemented [line 353 of Fintroller][6]

## Miscellaneous

- [x] Make function arguments more specific: rename "account" to "borrower" in all borrow-related functions, "repayAmount" to "borrowAmount" in the "Borrow" event, and "borrowAmount" to "mintAmount" in the "mint" function
- [x] Minor refactorings like reordering functions in Solidity and imports in TypeScript
- [x] Rename `CalculateClutchableCollateralLocalVars` to `GetClutchableCollateralLocalVars ` in `BalanceSheet.sol`
- [x] Remove unused "Vault" struct in `FyTokenStorage.sol`
- [x] Rename "setDebtCeiling" function to "setBondDebtCeiling" in `BalanceSheet.sol`
- [x] Reorder events emitted in the "borrow" and "repayBorrow" functions - "Mint" and "Burn" are both immediately followed by "Transfer" now, and "SetVaultDebt", "Borrow" and "RepayBorrow" come last
- [x] Upgrade to @paulrberg/contracts@1.3.0 and pin its semver, a release that renamed one function and a few function and event arguments

[1]: https://github.com/MainframeHQ/mainframe-lending-protocol/tree/f77b7f3dac89cab535f562af7b7913a927709bb5
[2]: https://github.com/PaulRBerg/contracts/tree/6c3ee4a37753807c917b10a06a69971e177eaf97
[3]: https://github.com/paulrberg/contracts
[4]: https://github.com/MainframeHQ/mainframe-lending-protocol/blob/f77b7f3dac89cab535f562af7b7913a927709bb5/contracts/Fintroller.sol#L346
[5]: https://github.com/MainframeHQ/mainframe-lending-protocol/blob/f77b7f3dac89cab535f562af7b7913a927709bb5/contracts/FyToken.sol#L309
[6]: https://github.com/MainframeHQ/mainframe-lending-protocol/blob/f77b7f3dac89cab535f562af7b7913a927709bb5/contracts/Fintroller.sol#L353