### PR TITLE
fix: emit Transfer event on Redemption Pool actions

### DIFF
--- a/contracts/FyToken.sol
+++ b/contracts/FyToken.sol
@@ -160,7 +160,7 @@ contract FyToken is
         /* Effects: print the new fyTokens into existence. */
         mintInternal(msg.sender, borrowAmount);
 
-        /* Emit a Transfer and a Borrow event. */
+        /* Emit a Transfer event. */
         emit Transfer(address(this), msg.sender, borrowAmount);
 
         /* Interactions: increase the debt of the borrower account. */
@@ -175,7 +175,7 @@ contract FyToken is
     /**
      * @notice Destroys `burnAmount` tokens from `holder`, reducing the token supply.
      *
-     * @dev Emits a {Burn} event.
+     * @dev Emits a {Burn} and a {Transfer} event.
      *
      * Requirements:
      *
@@ -196,6 +196,9 @@ contract FyToken is
 
         /* Effects: burns the fyTokens. */
         burnInternal(holder, burnAmount);
+
+        /* Emit a Transfer event. */
+        emit Transfer(holder, address(this), burnAmount);
 
         return true;
     }
@@ -272,7 +275,7 @@ contract FyToken is
     /** @notice Prints new tokens into existence and assigns them to `beneficiary`,
      * increasing the total supply.
      *
-     * @dev Emits a {Mint} event.
+     * @dev Emits a {Mint} and a {Transfer} event.
      *
      * Requirements:
      *
@@ -292,6 +295,9 @@ contract FyToken is
 
         /* Effects: print the new fyTokens into existence. */
         mintInternal(beneficiary, mintAmount);
+
+        /* Emit a Transfer event. */
+        emit Transfer(address(this), beneficiary, mintAmount);
 
         return true;
     }

--- a/test/integration/redemptionPool/effects/redeemFyTokens.ts
+++ b/test/integration/redemptionPool/effects/redeemFyTokens.ts
@@ -52,5 +52,11 @@ export default function shouldBehaveLikeSupplyUnderlying(): void {
         .to.emit(this.contracts.fyToken, "Burn")
         .withArgs(this.accounts.maker, fyTokenAmount);
     });
+
+    it("emits a Transfer event", async function () {
+      await expect(this.contracts.redemptionPool.connect(this.signers.maker).redeemFyTokens(fyTokenAmount))
+        .to.emit(this.contracts.fyToken, "Transfer")
+        .withArgs(this.accounts.maker, this.contracts.fyToken.address, fyTokenAmount);
+    });
   });
 }

--- a/test/integration/redemptionPool/effects/supplyUnderlying.ts
+++ b/test/integration/redemptionPool/effects/supplyUnderlying.ts
@@ -42,4 +42,10 @@ export default function shouldBehaveLikeSupplyUnderlying(): void {
       .to.emit(this.contracts.fyToken, "Mint")
       .withArgs(this.accounts.maker, fyTokenAmount);
   });
+
+  it("emits a Transfer event", async function () {
+    await expect(this.contracts.redemptionPool.connect(this.signers.maker).supplyUnderlying(underlyingAmount))
+      .to.emit(this.contracts.fyToken, "Transfer")
+      .withArgs(this.contracts.fyToken.address, this.accounts.maker, fyTokenAmount);
+  });
 }


### PR DESCRIPTION
Commit [f77b7f3][1], which was used for our audit, contains a medium-severity issue. When calling any of the functions in the `RedemptionPool`, there is no `Transfer` event emitted, although tokens are being transferred by way of minted or burned.

Blockchain explorers like Etherscan [wouldn't have been able to index these transfers][2], leaving the impression that the protocol math is not sound (total supply > the total amount of borrows). The issue would have applied to our [subgraph][3] as well.

[1]: https://github.com/MainframeHQ/mainframe-lending-protocol/tree/f77b7f3dac89cab535f562af7b7913a927709bb5
[2]: https://info.etherscan.com/what-happens-when-erc-20-token-transfer-might-have-failed/
[3]: https://github.com/MainframeHQ/mainframe-subgraph