### PR TITLE
Chainlink Price Feed Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ $ yarn clean
 
 - Dan Robinson and Allan Niemerg, for their work on [The Yield Protocol: On-Chain Lending With Interest Rate
   Discovery](https://research.paradigm.xyz/Yield.pdf), which shaped many of our protocol design choices.
-- The Compound Finance team, for the [Open Price
-  Feed](https://compound.finance/docs/prices) and their math libraries.
+- The Chainlink team, for the [Price Feeds](https://docs.chain.link/docs/using-chainlink-reference-contracts).
+- The Compound Finance team, for their math libraries.
 - OpenZeppelin, for their [outstanding smart contract library](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts).
 
 ## Discussion

--- a/contracts/BalanceSheet.sol
+++ b/contracts/BalanceSheet.sol
@@ -11,7 +11,7 @@ import "./BalanceSheetInterface.sol";
 import "./FintrollerInterface.sol";
 import "./FyTokenInterface.sol";
 import "./oracles/OraclePriceUtils.sol";
-import "./oracles/IChainlinkOperator.sol";
+import "./oracles/ChainlinkOperatorInterface.sol";
 
 /**
  * @title BalanceSheet
@@ -24,7 +24,7 @@ contract BalanceSheet is
     Admin, /* two dependencies */
     Exponential /* two dependencies */
 {
-    using OraclePriceUtils for IChainlinkOperator;
+    using OraclePriceUtils for ChainlinkOperatorInterface;
     using SafeErc20 for Erc20Interface;
 
     modifier isVaultOpenForMsgSender(FyTokenInterface fyToken) {
@@ -89,7 +89,7 @@ contract BalanceSheet is
         }
 
         /* Grab the upscaled USD price of the underlying. */
-        IChainlinkOperator oracle = fintroller.oracle();
+        ChainlinkOperatorInterface oracle = fintroller.oracle();
         vars.oraclePricePrecisionScalar = fintroller.oraclePricePrecisionScalar();
         (vars.mathErr, vars.underlyingPriceUpscaled) = oracle.getAdjustedPrice(
             fyToken.underlying().symbol(),
@@ -201,7 +201,7 @@ contract BalanceSheet is
         require(debt > 0, "ERR_GET_HYPOTHETICAL_COLLATERALIZATION_RATIO_DEBT_ZERO");
 
         /* Grab the upscaled USD price of the collateral. */
-        IChainlinkOperator oracle = fintroller.oracle();
+        ChainlinkOperatorInterface oracle = fintroller.oracle();
         vars.oraclePricePrecisionScalar = fintroller.oraclePricePrecisionScalar();
         (vars.mathErr, vars.collateralPriceUpscaled) = oracle.getAdjustedPrice(
             fyToken.collateral().symbol(),

--- a/contracts/BalanceSheet.sol
+++ b/contracts/BalanceSheet.sol
@@ -11,7 +11,7 @@ import "./BalanceSheetInterface.sol";
 import "./FintrollerInterface.sol";
 import "./FyTokenInterface.sol";
 import "./oracles/OraclePriceUtils.sol";
-import "./oracles/UniswapAnchoredViewInterface.sol";
+import "./oracles/IChainlinkOperator.sol";
 
 /**
  * @title BalanceSheet
@@ -24,7 +24,7 @@ contract BalanceSheet is
     Admin, /* two dependencies */
     Exponential /* two dependencies */
 {
-    using OraclePriceUtils for UniswapAnchoredViewInterface;
+    using OraclePriceUtils for IChainlinkOperator;
     using SafeErc20 for Erc20Interface;
 
     modifier isVaultOpenForMsgSender(FyTokenInterface fyToken) {
@@ -89,7 +89,7 @@ contract BalanceSheet is
         }
 
         /* Grab the upscaled USD price of the underlying. */
-        UniswapAnchoredViewInterface oracle = fintroller.oracle();
+        IChainlinkOperator oracle = fintroller.oracle();
         vars.oraclePricePrecisionScalar = fintroller.oraclePricePrecisionScalar();
         (vars.mathErr, vars.underlyingPriceUpscaled) = oracle.getAdjustedPrice(
             fyToken.underlying().symbol(),
@@ -201,7 +201,7 @@ contract BalanceSheet is
         require(debt > 0, "ERR_GET_HYPOTHETICAL_COLLATERALIZATION_RATIO_DEBT_ZERO");
 
         /* Grab the upscaled USD price of the collateral. */
-        UniswapAnchoredViewInterface oracle = fintroller.oracle();
+        IChainlinkOperator oracle = fintroller.oracle();
         vars.oraclePricePrecisionScalar = fintroller.oraclePricePrecisionScalar();
         (vars.mathErr, vars.collateralPriceUpscaled) = oracle.getAdjustedPrice(
             fyToken.collateral().symbol(),

--- a/contracts/Fintroller.sol
+++ b/contracts/Fintroller.sol
@@ -6,7 +6,7 @@ import "@paulrberg/contracts/math/Exponential.sol";
 
 import "./FintrollerInterface.sol";
 import "./FyTokenInterface.sol";
-import "./oracles/UniswapAnchoredViewInterface.sol";
+import "./oracles/IChainlinkOperator.sol";
 
 /**
  * @notice Fintroller
@@ -401,7 +401,7 @@ contract Fintroller is
      * @param newOracle The new oracle contract.
      * @return bool true = success, otherwise it reverts.
      */
-    function setOracle(UniswapAnchoredViewInterface newOracle) external override onlyAdmin returns (bool) {
+    function setOracle(IChainlinkOperator newOracle) external override onlyAdmin returns (bool) {
         require(address(newOracle) != address(0x00), "ERR_SET_ORACLE_ZERO_ADDRESS");
         address oldOracle = address(oracle);
         oracle = newOracle;

--- a/contracts/Fintroller.sol
+++ b/contracts/Fintroller.sol
@@ -6,7 +6,7 @@ import "@paulrberg/contracts/math/Exponential.sol";
 
 import "./FintrollerInterface.sol";
 import "./FyTokenInterface.sol";
-import "./oracles/IChainlinkOperator.sol";
+import "./oracles/ChainlinkOperatorInterface.sol";
 
 /**
  * @notice Fintroller
@@ -401,7 +401,7 @@ contract Fintroller is
      * @param newOracle The new oracle contract.
      * @return bool true = success, otherwise it reverts.
      */
-    function setOracle(IChainlinkOperator newOracle) external override onlyAdmin returns (bool) {
+    function setOracle(ChainlinkOperatorInterface newOracle) external override onlyAdmin returns (bool) {
         require(address(newOracle) != address(0x00), "ERR_SET_ORACLE_ZERO_ADDRESS");
         address oldOracle = address(oracle);
         oracle = newOracle;

--- a/contracts/FintrollerInterface.sol
+++ b/contracts/FintrollerInterface.sol
@@ -62,7 +62,7 @@ abstract contract FintrollerInterface is FintrollerStorage {
 
     function setLiquidationIncentive(uint256 newLiquidationIncentiveMantissa) external virtual returns (bool);
 
-    function setOracle(UniswapAnchoredViewInterface newOracle) external virtual returns (bool);
+    function setOracle(IChainlinkOperator newOracle) external virtual returns (bool);
 
     function setRedeemFyTokensAllowed(FyTokenInterface fyToken, bool state) external virtual returns (bool);
 

--- a/contracts/FintrollerInterface.sol
+++ b/contracts/FintrollerInterface.sol
@@ -62,7 +62,7 @@ abstract contract FintrollerInterface is FintrollerStorage {
 
     function setLiquidationIncentive(uint256 newLiquidationIncentiveMantissa) external virtual returns (bool);
 
-    function setOracle(IChainlinkOperator newOracle) external virtual returns (bool);
+    function setOracle(ChainlinkOperatorInterface newOracle) external virtual returns (bool);
 
     function setRedeemFyTokensAllowed(FyTokenInterface fyToken, bool state) external virtual returns (bool);
 

--- a/contracts/FintrollerStorage.sol
+++ b/contracts/FintrollerStorage.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.7.0;
 import "@paulrberg/contracts/math/Exponential.sol";
 
 import "./FyTokenInterface.sol";
-import "./oracles/UniswapAnchoredViewInterface.sol";
+import "./oracles/IChainlinkOperator.sol";
 
 /**
  * @title FintrollerStorage
@@ -31,7 +31,7 @@ abstract contract FintrollerStorage is Exponential {
     /**
      * @notice The contract that provides price data for the collateral and the underlying asset.
      */
-    UniswapAnchoredViewInterface public oracle;
+    IChainlinkOperator public oracle;
 
     /**
      * @notice Multiplier representing the discount on collateral that a liquidator receives.

--- a/contracts/FintrollerStorage.sol
+++ b/contracts/FintrollerStorage.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.7.0;
 import "@paulrberg/contracts/math/Exponential.sol";
 
 import "./FyTokenInterface.sol";
-import "./oracles/IChainlinkOperator.sol";
+import "./oracles/ChainlinkOperatorInterface.sol";
 
 /**
  * @title FintrollerStorage
@@ -31,7 +31,7 @@ abstract contract FintrollerStorage is Exponential {
     /**
      * @notice The contract that provides price data for the collateral and the underlying asset.
      */
-    IChainlinkOperator public oracle;
+    ChainlinkOperatorInterface public oracle;
 
     /**
      * @notice Multiplier representing the discount on collateral that a liquidator receives.

--- a/contracts/FintrollerStorage.sol
+++ b/contracts/FintrollerStorage.sol
@@ -39,9 +39,9 @@ abstract contract FintrollerStorage is Exponential {
     uint256 public liquidationIncentiveMantissa;
 
     /**
-     * @notice The ratio between mantissa precision (1e18) and the oracle price precision (1e6).
+     * @notice The ratio between mantissa precision (1e18) and the oracle price precision (1e8).
      */
-    uint256 public constant oraclePricePrecisionScalar = 1.0e12;
+    uint256 public constant oraclePricePrecisionScalar = 1.0e10;
 
     /**
      * @dev The threshold below which the collateralization ratio cannot be set, equivalent to 100%.

--- a/contracts/FyToken.sol
+++ b/contracts/FyToken.sol
@@ -13,7 +13,7 @@ import "./BalanceSheetInterface.sol";
 import "./FintrollerInterface.sol";
 import "./FyTokenInterface.sol";
 import "./RedemptionPool.sol";
-import "./oracles/IChainlinkOperator.sol";
+import "./oracles/ChainlinkOperatorInterface.sol";
 
 /**
  * @title FyToken

--- a/contracts/FyToken.sol
+++ b/contracts/FyToken.sol
@@ -13,7 +13,7 @@ import "./BalanceSheetInterface.sol";
 import "./FintrollerInterface.sol";
 import "./FyTokenInterface.sol";
 import "./RedemptionPool.sol";
-import "./oracles/UniswapAnchoredViewInterface.sol";
+import "./oracles/IChainlinkOperator.sol";
 
 /**
  * @title FyToken

--- a/contracts/external/chainlink/IAggregatorV3.sol
+++ b/contracts/external/chainlink/IAggregatorV3.sol
@@ -1,0 +1,64 @@
+pragma solidity ^0.7.0;
+
+
+/**
+ * @dev `AggregatorV3Interface` by Chainlink
+ * @dev Source: https://docs.chain.link/docs/price-feeds-api-reference
+ */
+interface IAggregatorV3 {
+    /*
+     * @dev Get the number of decimals present in the response value
+     */
+    function decimals() external view returns (uint8);
+
+    /*
+     * @dev Get the description of the underlying aggregator that the proxy points to
+     */
+    function description() external view returns (string memory);
+
+    /*
+     * @dev Get the version representing the type of aggregator the proxy points to
+     */
+    function version() external view returns (uint256);
+
+    /**
+     * @dev Get data from a specific round
+     * @notice It raises "No data present" if there is no data to report
+     * @notice Consumers are encouraged to check they're receiving fresh data
+     * by inspecting the updatedAt and answeredInRound return values.
+     * @notice The round id is made up of the aggregator's round ID with the phase ID
+     * in the two highest order bytes (it ensures round IDs get larger as time moves forward)
+     * @param roundId The round ID
+     * @return roundId The round ID
+     * @return answer The price
+     * @return startedAt Timestamp of when the round started
+     * (Only some AggregatorV3Interface implementations return meaningful values)
+     * @return updatedAt Timestamp of when the round was updated (computed)
+     * @return answeredInRound The round ID of the round in which the answer was computed
+     * (Only some AggregatorV3Interface implementations return meaningful values)
+     */
+    function getRoundData(uint80 _roundId) external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    );
+
+    /**
+     * @dev Get data from the last round
+     * Should raise "No data present" if there is no data to report
+     * @return roundId The round ID
+     * @return answer The price
+     * @return startedAt Timestamp of when the round started
+     * @return updatedAt Timestamp of when the round was updated
+     * @return answeredInRound The round ID of the round in which the answer was computed
+     */
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    );
+}

--- a/contracts/external/chainlink/IAggregatorV3.sol
+++ b/contracts/external/chainlink/IAggregatorV3.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.7.0;
 
-
 /**
  * @dev `AggregatorV3Interface` by Chainlink
  * @dev Source: https://docs.chain.link/docs/price-feeds-api-reference
@@ -37,13 +36,16 @@ interface IAggregatorV3 {
      * @return answeredInRound The round ID of the round in which the answer was computed
      * (Only some AggregatorV3Interface implementations return meaningful values)
      */
-    function getRoundData(uint80 _roundId) external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    );
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
 
     /**
      * @dev Get data from the last round
@@ -54,11 +56,14 @@ interface IAggregatorV3 {
      * @return updatedAt Timestamp of when the round was updated
      * @return answeredInRound The round ID of the round in which the answer was computed
      */
-    function latestRoundData() external view returns (
-        uint80 roundId,
-        int256 answer,
-        uint256 startedAt,
-        uint256 updatedAt,
-        uint80 answeredInRound
-    );
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
 }

--- a/contracts/oracles/ChainlinkOperator.sol
+++ b/contracts/oracles/ChainlinkOperator.sol
@@ -2,16 +2,16 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "./IChainlinkOperator.sol";
+import "./ChainlinkOperatorInterface.sol";
 import "@paulrberg/contracts/token/erc20/Erc20Interface.sol";
 
 /**
  * @title ChainlinkOperator
  * @author Mainframe
- * @dev Strictly for test purposes. Do not use in production.
+ * @notice Manages and aggregates USD-quoted Chainlink price feeds.
  */
 // TODO: to be tested
-contract ChainlinkOperator is IChainlinkOperator {
+contract ChainlinkOperator is ChainlinkOperatorInterface {
     mapping(string => Feed) private _feeds;
     address private _owner;
 
@@ -29,7 +29,7 @@ contract ChainlinkOperator is IChainlinkOperator {
         _owner = msg.sender;
     }
 
-    /// @inheritdoc IChainlinkOperator
+    /// @inheritdoc ChainlinkOperatorInterface
     function price(string memory symbol) external view override feedExists(_feeds[symbol].id) returns (uint256) {
         require(!_feeds[symbol].disabled, "ChainlinkOperator: price feed is disabled for symbol");
 
@@ -37,7 +37,7 @@ contract ChainlinkOperator is IChainlinkOperator {
         return uint256(answer);
     }
 
-    /// @inheritdoc IChainlinkOperator
+    /// @inheritdoc ChainlinkOperatorInterface
     function addFeed(IAggregatorV3 feed, Erc20Interface asset) external override {
         uint8 decimals = feed.decimals();
         require(decimals == 8, "ChainlinkOperator: non-USD price feed");
@@ -45,17 +45,17 @@ contract ChainlinkOperator is IChainlinkOperator {
         _feeds[asset.symbol()] = Feed(address(feed), address(asset), false);
     }
 
-    /// @inheritdoc IChainlinkOperator
+    /// @inheritdoc ChainlinkOperatorInterface
     function getFeed(string memory symbol) external view override returns (Feed memory) {
         return _feeds[symbol];
     }
 
-    /// @inheritdoc IChainlinkOperator
+    /// @inheritdoc ChainlinkOperatorInterface
     function disableFeed(string memory symbol) external override feedExists(_feeds[symbol].id) onlyOwner {
         _feeds[symbol].disabled = true;
     }
 
-    /// @inheritdoc IChainlinkOperator
+    /// @inheritdoc ChainlinkOperatorInterface
     function enableFeed(string memory symbol) external override feedExists(_feeds[symbol].id) onlyOwner {
         _feeds[symbol].disabled = false;
     }

--- a/contracts/oracles/ChainlinkOperator.sol
+++ b/contracts/oracles/ChainlinkOperator.sol
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "./IChainlinkOperator.sol";
+import "@paulrberg/contracts/token/erc20/Erc20Interface.sol";
+
+/**
+ * @title ChainlinkOperator
+ * @author Mainframe
+ * @dev Strictly for test purposes. Do not use in production.
+ */
+// TODO: to be tested
+contract ChainlinkOperator is IChainlinkOperator {
+    mapping(string => Feed) private  _feeds;
+    address private _owner;
+
+    modifier onlyOwner() {
+        require(_owner == msg.sender, "ChainlinkOperator: caller is not owner of contract");
+        _;
+    }
+
+    modifier feedExists(address feedId) {
+        require(feedId != address(0), "ChainlinkOperator: price feed doesn't exist");
+        _;
+    }
+
+    constructor() {
+        _owner = msg.sender;
+    }
+
+    /// @inheritdoc IChainlinkOperator
+    function price(string memory symbol) external override feedExists(_feeds[symbol].id) view returns (uint256) {
+        require(!_feeds[symbol].disabled, "ChainlinkOperator: price feed is disabled for symbol");
+
+        (, int256 answer, , ,) = IAggregatorV3(_feeds[symbol].id).latestRoundData();
+        return uint256(answer);
+    }
+
+    /// @inheritdoc IChainlinkOperator
+    function addFeed(IAggregatorV3 feed, Erc20Interface asset) external override {
+        uint8 decimals = feed.decimals();
+        require(decimals == 8, "ChainlinkOperator: non-USD price feed");
+
+        _feeds[asset.symbol()] = Feed(
+            address(feed),
+            address(asset),
+            false
+        );
+    }
+
+    /// @inheritdoc IChainlinkOperator
+    function getFeed(string memory symbol) external override view returns (Feed memory) {
+        return _feeds[symbol];
+    }
+
+    /// @inheritdoc IChainlinkOperator
+    function disableFeed(string memory symbol) external override feedExists(_feeds[symbol].id) onlyOwner {
+        _feeds[symbol].disabled = true;
+    }
+
+    /// @inheritdoc IChainlinkOperator
+    function enableFeed(string memory symbol) external override feedExists(_feeds[symbol].id) onlyOwner {
+        _feeds[symbol].disabled = false;
+    }
+}

--- a/contracts/oracles/ChainlinkOperator.sol
+++ b/contracts/oracles/ChainlinkOperator.sol
@@ -43,6 +43,7 @@ contract ChainlinkOperator is ChainlinkOperatorInterface {
         require(decimals == 8, "ChainlinkOperator: non-USD price feed");
 
         _feeds[asset.symbol()] = Feed(address(feed), address(asset), false);
+        emit FeedAdded(address(feed), address(asset));
     }
 
     /// @inheritdoc ChainlinkOperatorInterface
@@ -53,10 +54,12 @@ contract ChainlinkOperator is ChainlinkOperatorInterface {
     /// @inheritdoc ChainlinkOperatorInterface
     function disableFeed(string memory symbol) external override feedExists(_feeds[symbol].id) onlyOwner {
         _feeds[symbol].disabled = true;
+        emit FeedDisabled(_feeds[symbol].id);
     }
 
     /// @inheritdoc ChainlinkOperatorInterface
     function enableFeed(string memory symbol) external override feedExists(_feeds[symbol].id) onlyOwner {
         _feeds[symbol].disabled = false;
+        emit FeedEnabled(_feeds[symbol].id);
     }
 }

--- a/contracts/oracles/ChainlinkOperator.sol
+++ b/contracts/oracles/ChainlinkOperator.sol
@@ -12,7 +12,7 @@ import "@paulrberg/contracts/token/erc20/Erc20Interface.sol";
  */
 // TODO: to be tested
 contract ChainlinkOperator is IChainlinkOperator {
-    mapping(string => Feed) private  _feeds;
+    mapping(string => Feed) private _feeds;
     address private _owner;
 
     modifier onlyOwner() {
@@ -30,10 +30,10 @@ contract ChainlinkOperator is IChainlinkOperator {
     }
 
     /// @inheritdoc IChainlinkOperator
-    function price(string memory symbol) external override feedExists(_feeds[symbol].id) view returns (uint256) {
+    function price(string memory symbol) external view override feedExists(_feeds[symbol].id) returns (uint256) {
         require(!_feeds[symbol].disabled, "ChainlinkOperator: price feed is disabled for symbol");
 
-        (, int256 answer, , ,) = IAggregatorV3(_feeds[symbol].id).latestRoundData();
+        (, int256 answer, , , ) = IAggregatorV3(_feeds[symbol].id).latestRoundData();
         return uint256(answer);
     }
 
@@ -42,15 +42,11 @@ contract ChainlinkOperator is IChainlinkOperator {
         uint8 decimals = feed.decimals();
         require(decimals == 8, "ChainlinkOperator: non-USD price feed");
 
-        _feeds[asset.symbol()] = Feed(
-            address(feed),
-            address(asset),
-            false
-        );
+        _feeds[asset.symbol()] = Feed(address(feed), address(asset), false);
     }
 
     /// @inheritdoc IChainlinkOperator
-    function getFeed(string memory symbol) external override view returns (Feed memory) {
+    function getFeed(string memory symbol) external view override returns (Feed memory) {
         return _feeds[symbol];
     }
 

--- a/contracts/oracles/ChainlinkOperatorInterface.sol
+++ b/contracts/oracles/ChainlinkOperatorInterface.sol
@@ -6,11 +6,10 @@ import "../external/chainlink/IAggregatorV3.sol";
 import "@paulrberg/contracts/token/erc20/Erc20Interface.sol";
 
 /**
- * @title IChainlinkOperator
+ * @title ChainlinkOperatorInterface
  * @author Mainframe
- * @notice Interface mainframe's Chainlink pricefeed operator.
  */
-interface IChainlinkOperator {
+interface ChainlinkOperatorInterface {
     struct Feed {
         address id; // Chainlink price feed contract address
         address asset; // contract address of token that price feed is tracking value of

--- a/contracts/oracles/ChainlinkOperatorInterface.sol
+++ b/contracts/oracles/ChainlinkOperatorInterface.sol
@@ -48,4 +48,8 @@ interface ChainlinkOperatorInterface {
      * @param symbol The symbol of asset to enable price feed of.
      */
     function enableFeed(string memory symbol) external;
+
+    event FeedAdded(address indexed feedId, address indexed asset);
+    event FeedDisabled(address indexed feedId);
+    event FeedEnabled(address indexed feedId);
 }

--- a/contracts/oracles/IChainlinkOperator.sol
+++ b/contracts/oracles/IChainlinkOperator.sol
@@ -1,5 +1,9 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../external/chainlink/IAggregatorV3.sol";
+import "@paulrberg/contracts/token/erc20/Erc20Interface.sol";
 
 /**
  * @title IChainlinkOperator
@@ -7,10 +11,42 @@ pragma solidity ^0.7.0;
  * @notice Interface mainframe's Chainlink pricefeed operator.
  */
 interface IChainlinkOperator {
+    struct Feed {
+        address id;     // Chainlink price feed contract address
+        address asset;  // contract address of token that price feed is tracking value of
+        bool disabled;  // false by default
+    }
+
     /**
      * @notice Get the official price for a symbol.
      * @param symbol The symbol to fetch the price of.
      * @return Price denominated in USD, with 8 decimals.
      */
     function price(string memory symbol) external view returns (uint256);
+
+    /**
+     * @notice Add a new Chainlink price feed.
+     * @param feed The Chainlink price feed contract.
+     * @param asset The contract of asset to add price feed of.
+     */
+    function addFeed(IAggregatorV3 feed, Erc20Interface asset) external;
+
+    /**
+     * @notice Get the official feed for a symbol.
+     * @param symbol The symbol to return the price feed data of.
+     * @return Price feed data.
+     */
+    function getFeed(string memory symbol) external view returns (Feed memory);
+
+    /**
+     * @notice Disable a Chainlink price feed.
+     * @param symbol The symbol of asset to disable price feed of.
+     */
+    function disableFeed(string memory symbol) external;
+
+    /**
+     * @notice Disable a Chainlink price feed.
+     * @param symbol The symbol of asset to enable price feed of.
+     */
+    function enableFeed(string memory symbol) external;
 }

--- a/contracts/oracles/IChainlinkOperator.sol
+++ b/contracts/oracles/IChainlinkOperator.sol
@@ -12,9 +12,9 @@ import "@paulrberg/contracts/token/erc20/Erc20Interface.sol";
  */
 interface IChainlinkOperator {
     struct Feed {
-        address id;     // Chainlink price feed contract address
-        address asset;  // contract address of token that price feed is tracking value of
-        bool disabled;  // false by default
+        address id; // Chainlink price feed contract address
+        address asset; // contract address of token that price feed is tracking value of
+        bool disabled; // false by default
     }
 
     /**

--- a/contracts/oracles/IChainlinkOperator.sol
+++ b/contracts/oracles/IChainlinkOperator.sol
@@ -10,7 +10,7 @@ interface IChainlinkOperator {
     /**
      * @notice Get the official price for a symbol.
      * @param symbol The symbol to fetch the price of.
-     * @return Price denominated in USD, with 6 decimals.
+     * @return Price denominated in USD, with 8 decimals.
      */
     function price(string memory symbol) external view returns (uint256);
 }

--- a/contracts/oracles/IChainlinkOperator.sol
+++ b/contracts/oracles/IChainlinkOperator.sol
@@ -2,12 +2,11 @@
 pragma solidity ^0.7.0;
 
 /**
- * @title UniswapAnchoredViewInterface
+ * @title IChainlinkOperator
  * @author Mainframe
- * @notice Interface for accessing the Compound Open Price Feed.
- * https://compound.finance/docs/prices
+ * @notice Interface mainframe's Chainlink pricefeed operator.
  */
-interface UniswapAnchoredViewInterface {
+interface IChainlinkOperator {
     /**
      * @notice Get the official price for a symbol.
      * @param symbol The symbol to fetch the price of.

--- a/contracts/oracles/OraclePriceUtils.sol
+++ b/contracts/oracles/OraclePriceUtils.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.7.0;
 
 import "@paulrberg/contracts/math/CarefulMath.sol";
-import "./IChainlinkOperator.sol";
+import "./ChainlinkOperatorInterface.sol";
 
 /**
  * @title OraclePriceUtils
@@ -25,7 +25,7 @@ library OraclePriceUtils {
      * @return The upscaled price as a mantissa.
      */
     function getAdjustedPrice(
-        IChainlinkOperator oracle,
+        ChainlinkOperatorInterface oracle,
         string memory symbol,
         uint256 precisionScalar
     ) internal view returns (MathError, uint256) {

--- a/contracts/oracles/OraclePriceUtils.sol
+++ b/contracts/oracles/OraclePriceUtils.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.7.0;
 
 import "@paulrberg/contracts/math/CarefulMath.sol";
-import "./UniswapAnchoredViewInterface.sol";
+import "./IChainlinkOperator.sol";
 
 /**
  * @title OraclePriceUtils
@@ -25,7 +25,7 @@ library OraclePriceUtils {
      * @return The upscaled price as a mantissa.
      */
     function getAdjustedPrice(
-        UniswapAnchoredViewInterface oracle,
+        IChainlinkOperator oracle,
         string memory symbol,
         uint256 precisionScalar
     ) internal view returns (MathError, uint256) {

--- a/contracts/oracles/OraclePriceUtils.sol
+++ b/contracts/oracles/OraclePriceUtils.sol
@@ -7,12 +7,12 @@ import "./IChainlinkOperator.sol";
 /**
  * @title OraclePriceUtils
  * @author Mainframe
- * @notice Parses the price data returned by the Compound Open Price Feed
+ * @notice Parses the price data returned by the Chainlink USD price feed
  * to the format expected by Mainframe.
  */
 library OraclePriceUtils {
     /**
-     * @notice Converts the 6 decimal prices returned by the Open Price Feed to mantissa form,
+     * @notice Converts the 8 decimal prices returned by the Chainlink USD price feed to mantissa form,
      * which has 18 decimals.
      *
      * @dev Requirements:

--- a/contracts/test/SimplePriceOracleView.sol
+++ b/contracts/test/SimplePriceOracleView.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.7.0;
 import "../oracles/IChainlinkOperator.sol";
 
 /**
- * @title SimpleUniswapAnchoredView
+ * @title SimplePriceOracleView
  * @author Mainframe
  * @dev Strictly for testing purposes. Do not use in production.
  */
-contract SimpleUniswapAnchoredView {
+contract SimplePriceOracleView {
     uint256 public daiPrice;
     uint256 public wethPrice;
 

--- a/contracts/test/SimplePriceOracleView.sol
+++ b/contracts/test/SimplePriceOracleView.sol
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 pragma solidity ^0.7.0;
 
-import "../oracles/IChainlinkOperator.sol";
+import "../oracles/ChainlinkOperatorInterface.sol";
 
 /**
  * @title SimplePriceOracleView

--- a/contracts/test/SimpleUniswapAnchoredView.sol
+++ b/contracts/test/SimpleUniswapAnchoredView.sol
@@ -13,8 +13,8 @@ contract SimpleUniswapAnchoredView is IChainlinkOperator {
     uint256 public wethPrice;
 
     constructor() {
-        daiPrice = 1000000; /* $1 */
-        wethPrice = 100000000; /* $100 */
+        daiPrice = 100000000; /* $1 */
+        wethPrice = 10000000000; /* $100 */
     }
 
     function setDaiPrice(uint256 newDaiPrice) external {
@@ -26,8 +26,8 @@ contract SimpleUniswapAnchoredView is IChainlinkOperator {
     }
 
     /**
-     * @notice Prices are returned in the format that the Open Price Feed uses, i.e. 6 decimals of precision.
-     * @dev See https://compound.finance/docs/prices#price
+     * @notice Prices are returned in the format that the Chainlink USD price feeds use, i.e. 8 decimals of precision.
+     * @dev See https://docs.chain.link/docs/using-chainlink-reference-contracts
      */
     function price(string memory symbol) external view override returns (uint256) {
         if (areStringsEqual(symbol, "ETH")) {

--- a/contracts/test/SimpleUniswapAnchoredView.sol
+++ b/contracts/test/SimpleUniswapAnchoredView.sol
@@ -1,14 +1,14 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 pragma solidity ^0.7.0;
 
-import "../oracles/UniswapAnchoredViewInterface.sol";
+import "../oracles/IChainlinkOperator.sol";
 
 /**
  * @title SimpleUniswapAnchoredView
  * @author Mainframe
  * @dev Strictly for testing purposes. Do not use in production.
  */
-contract SimpleUniswapAnchoredView is UniswapAnchoredViewInterface {
+contract SimpleUniswapAnchoredView is IChainlinkOperator {
     uint256 public daiPrice;
     uint256 public wethPrice;
 

--- a/contracts/test/SimpleUniswapAnchoredView.sol
+++ b/contracts/test/SimpleUniswapAnchoredView.sol
@@ -8,7 +8,7 @@ import "../oracles/IChainlinkOperator.sol";
  * @author Mainframe
  * @dev Strictly for testing purposes. Do not use in production.
  */
-contract SimpleUniswapAnchoredView is IChainlinkOperator {
+contract SimpleUniswapAnchoredView {
     uint256 public daiPrice;
     uint256 public wethPrice;
 
@@ -29,7 +29,7 @@ contract SimpleUniswapAnchoredView is IChainlinkOperator {
      * @notice Prices are returned in the format that the Chainlink USD price feeds use, i.e. 8 decimals of precision.
      * @dev See https://docs.chain.link/docs/using-chainlink-reference-contracts
      */
-    function price(string memory symbol) external view override returns (uint256) {
+    function price(string memory symbol) external view returns (uint256) {
         if (areStringsEqual(symbol, "ETH")) {
             return wethPrice;
         } else if (areStringsEqual(symbol, "DAI")) {

--- a/contracts/test/TestOraclePriceUtils.sol
+++ b/contracts/test/TestOraclePriceUtils.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.7.0;
 
 import "@paulrberg/contracts/math/CarefulMath.sol";
 import "../oracles/OraclePriceUtils.sol";
-import "../oracles/UniswapAnchoredViewInterface.sol";
+import "../oracles/IChainlinkOperator.sol";
 
 /**
  * @title TestOraclePriceUtils
@@ -11,11 +11,11 @@ import "../oracles/UniswapAnchoredViewInterface.sol";
  * @dev Strictly for test purposes. Do not use in production.
  */
 contract TestOraclePriceUtils {
-    using OraclePriceUtils for UniswapAnchoredViewInterface;
+    using OraclePriceUtils for IChainlinkOperator;
 
-    UniswapAnchoredViewInterface public oracle;
+    IChainlinkOperator public oracle;
 
-    constructor(UniswapAnchoredViewInterface oracle_) {
+    constructor(IChainlinkOperator oracle_) {
         oracle = oracle_;
     }
 

--- a/contracts/test/TestOraclePriceUtils.sol
+++ b/contracts/test/TestOraclePriceUtils.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.7.0;
 
 import "@paulrberg/contracts/math/CarefulMath.sol";
 import "../oracles/OraclePriceUtils.sol";
-import "../oracles/IChainlinkOperator.sol";
+import "../oracles/ChainlinkOperatorInterface.sol";
 
 /**
  * @title TestOraclePriceUtils
@@ -11,11 +11,11 @@ import "../oracles/IChainlinkOperator.sol";
  * @dev Strictly for test purposes. Do not use in production.
  */
 contract TestOraclePriceUtils {
-    using OraclePriceUtils for IChainlinkOperator;
+    using OraclePriceUtils for ChainlinkOperatorInterface;
 
-    IChainlinkOperator public oracle;
+    ChainlinkOperatorInterface public oracle;
 
-    constructor(IChainlinkOperator oracle_) {
+    constructor(ChainlinkOperatorInterface oracle_) {
         oracle = oracle_;
     }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -47,7 +47,7 @@ const config: HardhatUserConfig = {
   gasReporter: {
     currency: "USD",
     enabled: process.env.REPORT_GAS ? true : false,
-    excludeContracts: ["Erc20Mintable", "SimpleUniswapAnchoredView", "TestOraclePriceUtils"],
+    excludeContracts: ["Erc20Mintable", "SimplePriceOracleView", "TestOraclePriceUtils"],
     src: "./contracts",
   },
   networks: {

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -13,7 +13,9 @@ export const tenMillion: BigNumber = ten.pow(7);
 export const fiftyMillion: BigNumber = tenMillion.mul(50);
 export const defaultNumberOfDecimals: BigNumber = BigNumber.from(18);
 export const chainlinkPriceFeedPrecision: BigNumber = BigNumber.from(8);
-export const chainlinkPriceFeedPrecisionScalar: BigNumber = ten.pow(defaultNumberOfDecimals.sub(chainlinkPriceFeedPrecision));
+export const chainlinkPriceFeedPrecisionScalar: BigNumber = ten.pow(
+  defaultNumberOfDecimals.sub(chainlinkPriceFeedPrecision),
+);
 
 /* Represented as mantissas (decimal scalars with 18 decimals). */
 export const percentages: { [name: string]: BigNumber } = {

--- a/helpers/constants.ts
+++ b/helpers/constants.ts
@@ -12,8 +12,8 @@ export const ten: BigNumber = BigNumber.from(10);
 export const tenMillion: BigNumber = ten.pow(7);
 export const fiftyMillion: BigNumber = tenMillion.mul(50);
 export const defaultNumberOfDecimals: BigNumber = BigNumber.from(18);
-export const openPriceFeedPrecision: BigNumber = BigNumber.from(6);
-export const openPriceFeedPrecisionScalar: BigNumber = ten.pow(defaultNumberOfDecimals.sub(openPriceFeedPrecision));
+export const chainlinkPriceFeedPrecision: BigNumber = BigNumber.from(8);
+export const chainlinkPriceFeedPrecisionScalar: BigNumber = ten.pow(defaultNumberOfDecimals.sub(chainlinkPriceFeedPrecision));
 
 /* Represented as mantissas (decimal scalars with 18 decimals). */
 export const percentages: { [name: string]: BigNumber } = {
@@ -32,11 +32,11 @@ export const precisionScalars = {
   tokenWithEighteenDecimals: One,
 };
 
-/* Prices with 6 decimals, as per the Open Price Feed format. */
+/* Prices with 8 decimals, as per Chainlink USD price feed format. */
 export const prices: { [name: string]: BigNumber } = {
-  oneDollar: ten.pow(6),
-  twelveDollars: ten.pow(6).mul(12),
-  oneHundredDollars: ten.pow(8),
+  oneDollar: ten.pow(8),
+  twelveDollars: ten.pow(8).mul(12),
+  oneHundredDollars: ten.pow(10),
 };
 
 /* These amounts assume that the token has 18 decimals. */
@@ -105,7 +105,7 @@ export const fintrollerConstants = {
   defaultCollateralizationRatio: percentages.oneHundredAndFifty,
   liquidationIncentiveLowerBoundMantissa: percentages.oneHundred,
   liquidationIncentiveUpperBoundMantissa: percentages.oneHundredAndFifty,
-  oraclePrecisionScalar: openPriceFeedPrecisionScalar,
+  oraclePrecisionScalar: chainlinkPriceFeedPrecisionScalar,
 };
 
 /* TODO: make the name and symbol match the expiration time */

--- a/test/deployers.ts
+++ b/test/deployers.ts
@@ -11,7 +11,7 @@ import GodModeBalanceSheetArtifact from "../artifacts/contracts/test/GodModeBala
 import GodModeFyTokenArtifact from "../artifacts/contracts/test/GodModeFyToken.sol/GodModeFyToken.json";
 import GodModeRedemptionPoolArtifact from "../artifacts/contracts/test/GodModRedemptionPool.sol/GodModeRedemptionPool.json";
 import OraclePriceUtilsArtifact from "../artifacts/contracts/test/TestOraclePriceUtils.sol/TestOraclePriceUtils.json";
-import SimpleUniswapAnchoredViewArtifact from "../artifacts/contracts/test/SimpleUniswapAnchoredView.sol/SimpleUniswapAnchoredView.json";
+import SimplePriceOracleViewArtifact from "../artifacts/contracts/test/SimplePriceOracleView.sol/SimplePriceOracleView.json";
 import scenarios from "./scenarios";
 
 import { BalanceSheet } from "../typechain/BalanceSheet";
@@ -21,7 +21,7 @@ import { FyToken } from "../typechain/FyToken";
 import { GodModeBalanceSheet } from "../typechain/GodModeBalanceSheet";
 import { GodModeRedemptionPool } from "../typechain/GodModeRedemptionPool";
 import { GodModeFyToken } from "../typechain/GodModeFyToken";
-import { SimpleUniswapAnchoredView } from "../typechain/SimpleUniswapAnchoredView";
+import { SimplePriceOracleView } from "../typechain/SimplePriceOracleView";
 import { TestOraclePriceUtils as OraclePriceUtils } from "../typechain/TestOraclePriceUtils";
 import { fyTokenConstants, gasLimits } from "../helpers/constants";
 
@@ -158,14 +158,14 @@ export async function deployOraclePriceUtils(deployer: Signer, oracleAddress: st
   return oraclePriceUtils;
 }
 
-export async function deploySimpleUniswapAnchoredView(deployer: Signer): Promise<SimpleUniswapAnchoredView> {
-  const simpleUniswapAnchoredView: SimpleUniswapAnchoredView = (await deployContract(
+export async function deploySimplePriceOracleView(deployer: Signer): Promise<SimplePriceOracleView> {
+  const SimplePriceOracleView: SimplePriceOracleView = (await deployContract(
     deployer,
-    SimpleUniswapAnchoredViewArtifact,
+    SimplePriceOracleViewArtifact,
     [],
     overrideOptions,
-  )) as SimpleUniswapAnchoredView;
-  return simpleUniswapAnchoredView;
+  )) as SimplePriceOracleView;
+  return SimplePriceOracleView;
 }
 
 export async function deployUnderlying(deployer: Signer): Promise<Erc20Mintable> {

--- a/test/deployers.ts
+++ b/test/deployers.ts
@@ -21,7 +21,7 @@ import { FyToken } from "../typechain/FyToken";
 import { GodModeBalanceSheet } from "../typechain/GodModeBalanceSheet";
 import { GodModeRedemptionPool } from "../typechain/GodModeRedemptionPool";
 import { GodModeFyToken } from "../typechain/GodModeFyToken";
-import { SimplePriceOracleView } from "../typechain/SimplePriceOracleView";
+import { SimplePriceOracleView as _SimplePriceOracleView } from "../typechain/SimplePriceOracleView";
 import { TestOraclePriceUtils as OraclePriceUtils } from "../typechain/TestOraclePriceUtils";
 import { fyTokenConstants, gasLimits } from "../helpers/constants";
 
@@ -158,13 +158,13 @@ export async function deployOraclePriceUtils(deployer: Signer, oracleAddress: st
   return oraclePriceUtils;
 }
 
-export async function deploySimplePriceOracleView(deployer: Signer): Promise<SimplePriceOracleView> {
-  const SimplePriceOracleView: SimplePriceOracleView = (await deployContract(
+export async function deploySimplePriceOracleView(deployer: Signer): Promise<_SimplePriceOracleView> {
+  const SimplePriceOracleView: _SimplePriceOracleView = (await deployContract(
     deployer,
     SimplePriceOracleViewArtifact,
     [],
     overrideOptions,
-  )) as SimplePriceOracleView;
+  )) as _SimplePriceOracleView;
   return SimplePriceOracleView;
 }
 

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -5,14 +5,14 @@ import { Fintroller } from "../../typechain/Fintroller";
 import { GodModeBalanceSheet } from "../../typechain/GodModeBalanceSheet";
 import { GodModeFyToken } from "../../typechain/GodModeFyToken";
 import { GodModeRedemptionPool } from "../../typechain/GodModeRedemptionPool";
-import { SimpleUniswapAnchoredView } from "../../typechain/SimpleUniswapAnchoredView";
+import { SimplePriceOracleView } from "../../typechain/SimplePriceOracleView";
 import {
   deployCollateral,
   deployFintroller,
   deployGodModeBalanceSheet,
   deployGodModeFyToken,
   deployGodModeRedemptionPool,
-  deploySimpleUniswapAnchoredView,
+  deploySimplePriceOracleView,
   deployUnderlying,
 } from "../deployers";
 import { fyTokenConstants } from "../../helpers/constants";
@@ -22,7 +22,7 @@ type IntegrationFixtureReturnType = {
   collateral: Erc20Mintable;
   fintroller: Fintroller;
   fyToken: GodModeFyToken;
-  oracle: SimpleUniswapAnchoredView;
+  oracle: SimplePriceOracleView;
   redemptionPool: GodModeRedemptionPool;
   underlying: Erc20Mintable;
 };
@@ -30,7 +30,7 @@ type IntegrationFixtureReturnType = {
 export async function integrationFixture(signers: Signer[]): Promise<IntegrationFixtureReturnType> {
   const deployer: Signer = signers[0];
 
-  const oracle: SimpleUniswapAnchoredView = await deploySimpleUniswapAnchoredView(deployer);
+  const oracle: SimplePriceOracleView = await deploySimplePriceOracleView(deployer);
   const fintroller: Fintroller = await deployFintroller(deployer);
   await fintroller.connect(deployer).setOracle(oracle.address);
 

--- a/test/unit/oraclePriceUtils/view/getAdjustedPrice.ts
+++ b/test/unit/oraclePriceUtils/view/getAdjustedPrice.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 import scenarios from "../../../scenarios";
 
 import { OraclePriceUtilsErrors } from "../../../../helpers/errors";
-import { openPriceFeedPrecisionScalar } from "../../../../helpers/constants";
+import { chainlinkPriceFeedPrecisionScalar } from "../../../../helpers/constants";
 
 export default function shouldBehaveLikeGetAdjustedPrice(): void {
   /* We are not using "ETH" here because we're not mocking the oracle itself. */
@@ -20,7 +20,7 @@ export default function shouldBehaveLikeGetAdjustedPrice(): void {
 
     it("reverts", async function () {
       await expect(
-        this.contracts.oraclePriceUtils.testGetAdjustedPrice(unavailableSymbol, openPriceFeedPrecisionScalar),
+        this.contracts.oraclePriceUtils.testGetAdjustedPrice(unavailableSymbol, chainlinkPriceFeedPrecisionScalar),
       ).to.be.revertedWith(OraclePriceUtilsErrors.PriceZero);
     });
   });
@@ -39,9 +39,9 @@ export default function shouldBehaveLikeGetAdjustedPrice(): void {
         const collateralPrice: BigNumber = scenarios.local.oracle.prices.collateral;
         const adjustedPrice: BigNumber = await this.contracts.oraclePriceUtils.testGetAdjustedPrice(
           collateralSymbol,
-          openPriceFeedPrecisionScalar,
+          chainlinkPriceFeedPrecisionScalar,
         );
-        expect(adjustedPrice).to.equal(collateralPrice.mul(openPriceFeedPrecisionScalar));
+        expect(adjustedPrice).to.equal(collateralPrice.mul(chainlinkPriceFeedPrecisionScalar));
       });
     });
   });

--- a/test/unit/stubs.ts
+++ b/test/unit/stubs.ts
@@ -12,7 +12,7 @@ import RedemptionPoolArtifact from "../../artifacts/contracts/RedemptionPool.sol
 import SimpleUniswapAnchoredViewArtifact from "../../artifacts/contracts/test/SimpleUniswapAnchoredView.sol/SimpleUniswapAnchoredView.json";
 import scenarios from "../scenarios";
 
-import { balanceSheetConstants, etherSymbol, openPriceFeedPrecision } from "../../helpers/constants";
+import { balanceSheetConstants, etherSymbol, chainlinkPriceFeedPrecision } from "../../helpers/constants";
 
 const { deployMockContract: deployStubContract } = waffle;
 
@@ -52,7 +52,7 @@ export async function deployStubErc20(
 export async function deployStubFintroller(deployer: Signer): Promise<MockContract> {
   const fintroller: MockContract = await deployStubContract(deployer, FintrollerArtifact.abi);
   await fintroller.mock.isFintroller.returns(true);
-  await fintroller.mock.oraclePricePrecisionScalar.returns(openPriceFeedPrecision);
+  await fintroller.mock.oraclePricePrecisionScalar.returns(chainlinkPriceFeedPrecision);
   return fintroller;
 }
 

--- a/test/unit/stubs.ts
+++ b/test/unit/stubs.ts
@@ -9,7 +9,7 @@ import Erc20Artifact from "../../artifacts/@paulrberg/contracts/token/erc20/Erc2
 import FintrollerArtifact from "../../artifacts/contracts/Fintroller.sol/Fintroller.json";
 import FyTokenArtifact from "../../artifacts/contracts/FyToken.sol/FyToken.json";
 import RedemptionPoolArtifact from "../../artifacts/contracts/RedemptionPool.sol/RedemptionPool.json";
-import SimpleUniswapAnchoredViewArtifact from "../../artifacts/contracts/test/SimpleUniswapAnchoredView.sol/SimpleUniswapAnchoredView.json";
+import SimplePriceOracleViewArtifact from "../../artifacts/contracts/test/SimplePriceOracleView.sol/SimplePriceOracleView.json";
 import scenarios from "../scenarios";
 
 import { balanceSheetConstants, etherSymbol, chainlinkPriceFeedPrecision } from "../../helpers/constants";
@@ -63,7 +63,7 @@ export async function deployStubFyToken(deployer: Signer): Promise<MockContract>
 }
 
 export async function deployStubOracle(deployer: Signer): Promise<MockContract> {
-  const oracle: MockContract = await deployStubContract(deployer, SimpleUniswapAnchoredViewArtifact.abi);
+  const oracle: MockContract = await deployStubContract(deployer, SimplePriceOracleViewArtifact.abi);
   await oracle.mock.price.withArgs(etherSymbol).returns(scenarios.local.oracle.prices.collateral);
   await oracle.mock.price.withArgs(scenarios.local.underlying.symbol).returns(scenarios.local.oracle.prices.underlying);
   return oracle;

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,7 +11,7 @@ import { GodModeRedemptionPool } from "../typechain/GodModeRedemptionPool";
 import { GodModeFyToken } from "../typechain/GodModeFyToken";
 import { RedemptionPool } from "../typechain/RedemptionPool";
 import { TestOraclePriceUtils as OraclePriceUtils } from "../typechain/TestOraclePriceUtils";
-import { SimpleUniswapAnchoredView } from "../typechain/SimpleUniswapAnchoredView";
+import { SimplePriceOracleView } from "../typechain/SimplePriceOracleView";
 import { IChainlinkOperator } from "../typechain/IChainlinkOperator";
 
 /* Fingers-crossed that ethers.js or waffle will provide an easier way to cache the address */
@@ -31,7 +31,7 @@ export interface Contracts {
   collateral: Erc20Mintable;
   fintroller: Fintroller;
   fyToken: GodModeFyToken | FyToken;
-  oracle: SimpleUniswapAnchoredView | IChainlinkOperator;
+  oracle: SimplePriceOracleView | IChainlinkOperator;
   oraclePriceUtils: OraclePriceUtils;
   redemptionPool: GodModeRedemptionPool | RedemptionPool;
   underlying: Erc20Mintable;

--- a/types/index.ts
+++ b/types/index.ts
@@ -12,7 +12,7 @@ import { GodModeFyToken } from "../typechain/GodModeFyToken";
 import { RedemptionPool } from "../typechain/RedemptionPool";
 import { TestOraclePriceUtils as OraclePriceUtils } from "../typechain/TestOraclePriceUtils";
 import { SimpleUniswapAnchoredView } from "../typechain/SimpleUniswapAnchoredView";
-import { UniswapAnchoredViewInterface } from "../typechain/UniswapAnchoredViewInterface";
+import { IChainlinkOperator } from "../typechain/IChainlinkOperator";
 
 /* Fingers-crossed that ethers.js or waffle will provide an easier way to cache the address */
 export interface Accounts {
@@ -31,7 +31,7 @@ export interface Contracts {
   collateral: Erc20Mintable;
   fintroller: Fintroller;
   fyToken: GodModeFyToken | FyToken;
-  oracle: SimpleUniswapAnchoredView | UniswapAnchoredViewInterface;
+  oracle: SimpleUniswapAnchoredView | IChainlinkOperator;
   oraclePriceUtils: OraclePriceUtils;
   redemptionPool: GodModeRedemptionPool | RedemptionPool;
   underlying: Erc20Mintable;

--- a/types/index.ts
+++ b/types/index.ts
@@ -12,7 +12,7 @@ import { GodModeFyToken } from "../typechain/GodModeFyToken";
 import { RedemptionPool } from "../typechain/RedemptionPool";
 import { TestOraclePriceUtils as OraclePriceUtils } from "../typechain/TestOraclePriceUtils";
 import { SimplePriceOracleView } from "../typechain/SimplePriceOracleView";
-import { IChainlinkOperator } from "../typechain/IChainlinkOperator";
+import { ChainlinkOperatorInterface } from "../typechain/ChainlinkOperatorInterface";
 
 /* Fingers-crossed that ethers.js or waffle will provide an easier way to cache the address */
 export interface Accounts {
@@ -31,7 +31,7 @@ export interface Contracts {
   collateral: Erc20Mintable;
   fintroller: Fintroller;
   fyToken: GodModeFyToken | FyToken;
-  oracle: SimplePriceOracleView | IChainlinkOperator;
+  oracle: SimplePriceOracleView | ChainlinkOperatorInterface;
   oraclePriceUtils: OraclePriceUtils;
   redemptionPool: GodModeRedemptionPool | RedemptionPool;
   underlying: Erc20Mintable;


### PR DESCRIPTION
I made the least amount of changes needed to integrate Chainlink USD price feeds for Mainframe. The contracts are still untested, awaiting feedback to proceed with testing. The ChainlinkOperator serves a similar purpose to a phone operator, which is aggregating all possible feeds and connecting you to the needed price feed according to the token symbol provided. These changes were needed due to spec differences between Compound Open Price Feed and Chainlink price feeds.